### PR TITLE
Use formatter/parser for InputNumber units

### DIFF
--- a/src/components/quoteForm/FeedblockForm/FeedblockForm.tsx
+++ b/src/components/quoteForm/FeedblockForm/FeedblockForm.tsx
@@ -141,7 +141,8 @@ const FeedblockForm = forwardRef(
                   min={0}
                   controls={false}
                   style={{ width: "100%" }}
-                  suffix="kg/h"
+                  formatter={(value) => `${value}kg/h`}
+                  parser={(value) => value?.replace(/kg\/h/g, "") as any}
                 />
               </Form.Item>
             </Col>
@@ -361,7 +362,8 @@ const FeedblockForm = forwardRef(
                   min={0}
                   // precision={2}
                   style={{ width: "100%" }}
-                  suffix="kw"
+                  formatter={(value) => `${value}kw`}
+                  parser={(value) => value?.replace(/kw/g, "") as any}
                 />
               </Form.Item>
             </Col>

--- a/src/components/quoteForm/MeteringPumpForm/ModelOption.tsx
+++ b/src/components/quoteForm/MeteringPumpForm/ModelOption.tsx
@@ -409,7 +409,10 @@ export const ModelOption = () => {
                         ]}
                         initialValue=""
                       >
-                        <InputNumber addonAfter="KW" />
+                        <InputNumber
+                          formatter={(value) => `${value}KW`}
+                          parser={(value) => value?.replace(/KW/g, "") as any}
+                        />
                       </Form.Item>
                     </Col>
                     <Col xs={12} md={8}>

--- a/src/components/quoteForm/dieForm/DieInstall.tsx
+++ b/src/components/quoteForm/dieForm/DieInstall.tsx
@@ -98,7 +98,12 @@ export const DieInstall = () => {
                     label="小车中心高度"
                     rules={[{ required: true, message: "请输入中心高度" }]}
                   >
-                    <InputNumber min={0} step={0.1} addonAfter="m" />
+                    <InputNumber
+                      min={0}
+                      step={0.1}
+                      formatter={(value) => `${value}m`}
+                      parser={(value) => value?.replace(/m/g, "") as any}
+                    />
                   </Form.Item>
                 </Col>
               </>
@@ -130,7 +135,12 @@ export const DieInstall = () => {
             }
             rules={[{ required: true, message: "请输入电源连接线长度" }]}
           >
-            <InputNumber min={0} step={0.5} addonAfter="m" />
+            <InputNumber
+              min={0}
+              step={0.5}
+              formatter={(value) => `${value}m`}
+              parser={(value) => value?.replace(/m/g, "") as any}
+            />
           </Form.Item>
         </Col>
 
@@ -155,7 +165,12 @@ export const DieInstall = () => {
                     { required: true, message: "请输入热膨胀数据连接线长度" },
                   ]}
                 >
-                  <InputNumber min={0} step={0.5} addonAfter="m" />
+                  <InputNumber
+                    min={0}
+                    step={0.5}
+                    formatter={(value) => `${value}m`}
+                    parser={(value) => value?.replace(/m/g, "") as any}
+                  />
                 </Form.Item>
               </Col>
             ) : null;

--- a/src/components/quoteForm/formComponents/ScrewFormItem.tsx
+++ b/src/components/quoteForm/formComponents/ScrewFormItem.tsx
@@ -50,7 +50,8 @@ export const ScrewFormItem = ({ items }: { items: string[] }) => {
       <Col xs={12} sm={5}>
         <ProForm.Item name="temperature" label="工艺温度">
           <InputNumber
-            addonAfter="℃"
+            formatter={(value) => `${value}℃`}
+            parser={(value) => value?.replace(/℃/g, "") as any}
             min={0}
             max={999}
             precision={0}


### PR DESCRIPTION
## Summary
- replace addonAfter/suffix unit displays with `formatter` and `parser` on InputNumber components

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684838e2cd7483279e9e954b4832f400