### PR TITLE
Implement product name auto generation

### DIFF
--- a/src/components/quote/ProductConfigForm/ProductConfigModal.tsx
+++ b/src/components/quote/ProductConfigForm/ProductConfigModal.tsx
@@ -23,6 +23,9 @@ const ProductConfigModal: React.FC<ProductConfigModalProps> = ({
   const material = useQuoteStore(
     (state) => state.quotes.find((q) => q.id == quoteId)?.material
   );
+  const finalProduct = useQuoteStore(
+    (state) => state.quotes.find((q) => q.id == quoteId)?.finalProduct
+  );
   const formRef = useRef<{
     priceForm: FormInstance;
     modelForm: FormInstance;
@@ -175,6 +178,8 @@ const ProductConfigModal: React.FC<ProductConfigModalProps> = ({
         <ProductConfigurationForm
           quoteId={quoteId}
           quoteItem={quoteItem}
+          material={material || []}
+          finalProduct={finalProduct || []}
           ref={formRef}
         />
       </Modal>

--- a/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
+++ b/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
@@ -18,9 +18,14 @@ import FeedblockForm from "../../quoteForm/FeedblockForm/FeedblockForm";
 interface ProductConfigurationFormProps {
   quoteItem?: QuoteItem;
   quoteId: number;
+  material?: string[];
+  finalProduct?: string[];
 }
 const ProductConfigurationForm = forwardRef(
-  ({ quoteItem, quoteId }: ProductConfigurationFormProps, ref) => {
+  (
+    { quoteItem, quoteId, material = [], finalProduct = [] }: ProductConfigurationFormProps,
+    ref
+  ) => {
     const priceFormRef = useRef<{ form: FormInstance }>(null);
     const modelFormRef = useRef<{ form: FormInstance }>(null);
     const dieFormRef = useRef<{ form: FormInstance }>(null);
@@ -29,6 +34,34 @@ const ProductConfigurationForm = forwardRef(
     const meteringPumpFormRef = useRef<{ form: FormInstance }>(null);
     const feedblockFormRef = useRef<{ form: FormInstance }>(null);
     const [activeKey, setActiveKey] = useState("1");
+
+    const generateName = () => {
+      const category = quoteItem?.productCategory;
+      if (!category) return "";
+
+      if (category[0] === "平模") {
+        const mat = material.join("");
+        const final = finalProduct.join("");
+        return `${mat}${final}模头`;
+      }
+
+      if (category.at(-1) === "共挤复合分配器") {
+        const layers = modelFormRef.current?.form.getFieldValue("layers");
+        const extruder = modelFormRef.current?.form.getFieldValue("extruderNumber");
+        if (layers && extruder) {
+          return `${layers}共挤复合分配器（${extruder}）`;
+        }
+      }
+
+      if (category.at(-1) === "熔体计量泵") {
+        const model = modelFormRef.current?.form.getFieldValue("model");
+        if (model) {
+          return `${model}熔体计量泵`;
+        }
+      }
+
+      return "";
+    };
 
     const setForm = () => {
       const category = quoteItem?.productCategory;
@@ -101,7 +134,9 @@ const ProductConfigurationForm = forwardRef(
           {
             label: "价格配置",
             key: "2",
-            children: <PriceForm ref={priceFormRef} />,
+            children: (
+              <PriceForm ref={priceFormRef} onGenerateName={generateName} />
+            ),
             forceRender: true,
           },
         ]}

--- a/src/components/quoteForm/PriceForm.tsx
+++ b/src/components/quoteForm/PriceForm.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   Col,
   Form,
   FormInstance,
@@ -9,10 +10,14 @@ import {
   Space,
   Typography,
 } from "antd";
-import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
+import { forwardRef, useImperativeHandle } from "react";
 import { formatPrice } from "../../util/valueUtil";
 interface PriceFormRef {
   form: FormInstance; // 明确定义暴露的form实例
+}
+
+interface PriceFormProps {
+  onGenerateName?: () => string | undefined;
 }
 interface PriceFormValues {
   quantity: number;
@@ -27,12 +32,19 @@ const brandOption = [
   { value: "古迪", label: "古迪" },
 ];
 
-const PriceForm = forwardRef<PriceFormRef>((props, ref) => {
-  const [form] = Form.useForm<PriceFormValues>();
+const PriceForm = forwardRef<PriceFormRef, PriceFormProps>(
+  ({ onGenerateName }, ref) => {
+    const [form] = Form.useForm<PriceFormValues>();
   // 暴露form实例给父组件
   useImperativeHandle(ref, () => ({
     form,
   }));
+
+  const handleGenerateName = () => {
+    if (!onGenerateName) return;
+    const name = onGenerateName();
+    if (name) form.setFieldValue("productName", name);
+  };
   // 计算小计
 
   const handleValuesChange = (changedValues: any, allValues: any) => {
@@ -62,7 +74,10 @@ const PriceForm = forwardRef<PriceFormRef>((props, ref) => {
             label="产品名称"
             rules={[{ required: true, message: "请输入产品名称" }]}
           >
-            <Input style={{ width: "100%" }} />
+            <Space.Compact style={{ width: "100%" }}>
+              <Input style={{ width: "100%" }} />
+              <Button onClick={handleGenerateName}>生成</Button>
+            </Space.Compact>
           </Form.Item>
         </Col>
 


### PR DESCRIPTION
## Summary
- add button to generate product name in PriceForm
- compute product name based on product category in ProductConfigurationForm
- pass quote material and final product into configuration form

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68484585331083279766d442abdc3518