### PR TITLE
Show loading indicator while config form initializes

### DIFF
--- a/src/components/quote/ProductConfigForm/ProductConfigModal.tsx
+++ b/src/components/quote/ProductConfigForm/ProductConfigModal.tsx
@@ -1,4 +1,4 @@
-import { Modal, Form, Button, Spin, message } from "antd";
+import { Modal, Button, Skeleton } from "antd";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useQuoteStore } from "../../../store/useQuoteStore";
 import { FormInstance } from "antd/lib";
@@ -29,9 +29,11 @@ const ProductConfigModal: React.FC<ProductConfigModalProps> = ({
     switchTab: (key: string) => void;
   }>(null);
   const priceForm = formRef.current?.priceForm;
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (!quoteItem || !open) return;
+    setLoading(true);
     const { config, ...otherValue } = quoteItem;
 
     const basicValues = {
@@ -57,10 +59,14 @@ const ProductConfigModal: React.FC<ProductConfigModalProps> = ({
       formRef.current.priceForm?.setFieldsValue(basicValues);
       formRef.current.modelForm?.setFieldsValue(formValues);
       console.log(formRef.current.modelForm?.getFieldsValue());
+      setLoading(false);
     };
     // 添加延迟确保表单已渲染
     const timer = setTimeout(setFormFields, 100);
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+      setLoading(false);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, quoteItem]);
 
@@ -115,7 +121,6 @@ const ProductConfigModal: React.FC<ProductConfigModalProps> = ({
         console.error("Validation failed:", error);
       }
     } catch (error: any) {
-      // message.error(error.errorFields.map((e: any) => e.errors).join(","));
       formRef.current?.switchTab("1");
       console.error("Validation failed:", error);
     }
@@ -172,11 +177,17 @@ const ProductConfigModal: React.FC<ProductConfigModalProps> = ({
           </Button>,
         ]}
       >
-        <ProductConfigurationForm
-          quoteId={quoteId}
-          quoteItem={quoteItem}
-          ref={formRef}
-        />
+        {loading ? (
+          <div style={{ padding: 24 }}>
+            <Skeleton active paragraph={{ rows: 8 }} />
+          </div>
+        ) : (
+          <ProductConfigurationForm
+            quoteId={quoteId}
+            quoteItem={quoteItem}
+            ref={formRef}
+          />
+        )}
       </Modal>
     </>
   );


### PR DESCRIPTION
## Summary
- use `Skeleton` instead of `Spin` when `ProductConfigurationForm` is not ready
- remove unused imports

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684845f1ace483279b508730dabb4a47