### PR TITLE
Add InputWithButton component

### DIFF
--- a/src/components/general/InputWithButton.tsx
+++ b/src/components/general/InputWithButton.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Input, Button, Space } from "antd";
+import type { InputProps, ButtonProps } from "antd";
+
+export interface InputWithButtonProps
+  extends Omit<InputProps, "value" | "onChange"> {
+  /** Controlled value for the input */
+  value?: string;
+  /** Change handler for the input */
+  onChange?: (value: string) => void;
+  /** Text inside the button */
+  buttonText?: React.ReactNode;
+  /** Props passed to Button component */
+  buttonProps?: ButtonProps;
+  /** Click handler for the button */
+  onButtonClick?: () => void;
+}
+
+const InputWithButton: React.FC<InputWithButtonProps> = ({
+  value,
+  onChange,
+  buttonText = "Submit",
+  buttonProps,
+  onButtonClick,
+  ...inputProps
+}) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange?.(e.target.value);
+  };
+
+  return (
+    <Space.Compact style={{ width: "100%" }}>
+      <Input value={value} onChange={handleChange} {...inputProps} />
+      <Button type="primary" onClick={onButtonClick} {...buttonProps}>
+        {buttonText}
+      </Button>
+    </Space.Compact>
+  );
+};
+
+export default InputWithButton;

--- a/src/components/quoteForm/PriceForm.tsx
+++ b/src/components/quoteForm/PriceForm.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   Col,
   Form,
   FormInstance,
@@ -7,10 +6,10 @@ import {
   InputNumber,
   Row,
   Select,
-  Space,
   Typography,
 } from "antd";
 import { forwardRef, useImperativeHandle } from "react";
+import InputWithButton from "../general/InputWithButton";
 import { formatPrice } from "../../util/valueUtil";
 interface PriceFormRef {
   form: FormInstance; // 明确定义暴露的form实例
@@ -68,17 +67,10 @@ const PriceForm = forwardRef<PriceFormRef, PriceFormProps>(
               label="产品名称"
               rules={[{ required: true, message: "请输入产品名称" }]}
             >
-              <Input
+              <InputWithButton
                 style={{ width: "100%" }}
-                addonAfter={
-                  <Button
-                    type="primary"
-                    onClick={handleGenerateName}
-                    style={{ margin: 0 }}
-                  >
-                    自动生成名称
-                  </Button>
-                }
+                buttonText="自动生成名称"
+                onButtonClick={handleGenerateName}
               />
             </Form.Item>
           </Col>


### PR DESCRIPTION
## Summary
- create reusable `InputWithButton` component
- use `InputWithButton` in `PriceForm` for product name input

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: various module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_684854516ee08327b8e5944acc6e5829