### PR TITLE
Restrict tags and allow Chinese characters

### DIFF
--- a/src/components/general/MaterialSelect.tsx
+++ b/src/components/general/MaterialSelect.tsx
@@ -25,13 +25,22 @@ const MaterialSelect: React.FC<MaterialSelectProps> = ({
   placeholder = "输入材料，按回车确认",
   style,
 }) => {
+  const VALID_TAG = /^[\u4e00-\u9fa5\d%()（）]+$/;
+
   const handleChange = (newValue: string[]) => {
     if (onChange) {
-      // Convert all values to uppercase
-      const upperCaseValue = newValue.map((item) =>
-        item.replace(" ", "").toUpperCase()
-      );
-      onChange(upperCaseValue);
+      const cleaned = newValue
+        .map((item) => item.replace(/\s/g, ""))
+        .filter((item) => VALID_TAG.test(item));
+
+      onChange(cleaned);
+    }
+  };
+
+  const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    const { key } = e;
+    if (key.length === 1 && !/[\u4e00-\u9fa5\d%()（）]/.test(key)) {
+      e.preventDefault();
     }
   };
   return (
@@ -40,6 +49,7 @@ const MaterialSelect: React.FC<MaterialSelectProps> = ({
       placeholder={placeholder}
       disabled={disabled}
       mode="tags"
+      onInputKeyDown={handleInputKeyDown}
       options={selectOptions(MATERIAL)}
       value={value}
       onChange={handleChange}


### PR DESCRIPTION
## Summary
- permit Chinese, digits, `%`, and parentheses in `MaterialSelect`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68492d99b3d0832792764379d898210b