### PR TITLE
Update IntervalInput data format

### DIFF
--- a/src/components/general/IntervalInput.tsx
+++ b/src/components/general/IntervalInput.tsx
@@ -8,10 +8,13 @@ import React, {
 import { Form, Input } from "antd";
 import type { FormItemProps } from "antd";
 import { intervalInputRules } from "../../util/rules";
+import type { IntervalValue } from "../../types/types";
+
+const DELIMITER = "～";
 
 export interface IntervalInputProps {
-  value?: string;
-  onChange?: (value: string) => void;
+  value?: IntervalValue;
+  onChange?: (value: IntervalValue) => void;
   placeholder?: string;
   addonAfter?: string | null;
   addonBefore?: string | null;
@@ -28,7 +31,7 @@ export interface IntervalInputProps {
 const IntervalInput: React.FC<IntervalInputProps> = forwardRef(
   (
     {
-      value = "",
+      value,
       onChange = () => {},
       placeholder = "请输入数值",
       disabled = false,
@@ -42,7 +45,7 @@ const IntervalInput: React.FC<IntervalInputProps> = forwardRef(
     },
     ref
   ) => {
-    const [internalValue, setInternalValue] = useState(value);
+    const [internalValue, setInternalValue] = useState(value?.value ?? "");
     const [isFocused, setIsFocused] = useState(false);
     const inputRef = useRef<any>(null);
     const lastCursorPos = useRef(0);
@@ -58,21 +61,32 @@ const IntervalInput: React.FC<IntervalInputProps> = forwardRef(
     // );
 
     useEffect(() => {
-      setInternalValue(value);
+      setInternalValue(value?.value ?? "");
     }, [value]);
 
+    const constructValue = (val: string): IntervalValue => {
+      const [frontStr, rearStr] = val.split(DELIMITER);
+      return {
+        front: frontStr ? parseFloat(frontStr) : NaN,
+        rear: rearStr ? parseFloat(rearStr) : NaN,
+        value: val,
+        unit: unit ?? "",
+      };
+    };
+
     const customOnChange = (newValue: string) => {
+      const v = constructValue(newValue);
       if (extra) {
-        const e = { target: { value: newValue } };
+        const e = { target: { value: v } };
         onChange?.(e as any);
       } else {
-        onChange?.(newValue);
+        onChange?.(v);
       }
     };
 
     const formatDisplayValue = (val: string) => {
       let display = val;
-      if (!isFocused && display.endsWith("-")) {
+      if (!isFocused && display.endsWith(DELIMITER)) {
         display = display.slice(0, -1);
       }
       if (!isFocused && unit) {
@@ -84,26 +98,27 @@ const IntervalInput: React.FC<IntervalInputProps> = forwardRef(
     const validateInput = (input: string): boolean => {
       if (input === "") return true;
 
-      if (input.startsWith("-")) return false;
-      if ((input.match(/-/g) || []).length > 1) return false;
-
-      return /^\d*(?:-\d*)?$/.test(input);
+      return /^-?\d*(?:～-?\d*)?$/.test(input);
     };
 
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      let input = e.target.value.replace(/[^0-9-]/g, "");
+      let input = e.target.value.replace(/[^0-9-～]/g, "");
 
-      if (input.startsWith("-")) {
-        input = input.slice(1);
-      }
-
-      const dashIndex = input.indexOf("-");
-      if (dashIndex !== -1) {
+      const delimiterIndex = input.indexOf(DELIMITER);
+      if (delimiterIndex !== -1) {
         input =
-          input.slice(0, dashIndex + 1) +
-          input.slice(dashIndex + 1).replace(/-/g, "");
+          input.slice(0, delimiterIndex + 1) +
+          input.slice(delimiterIndex + 1).replace(new RegExp(DELIMITER, "g"), "");
       }
+
+      const parts = input.split(DELIMITER);
+      parts[0] = parts[0].replace(/(?!^)-/g, "");
+      if (parts[1] !== undefined) {
+        parts[1] = parts[1].replace(/(?!^)-/g, "");
+      }
+
+      input = parts.join(DELIMITER);
 
       if (validateInput(input)) {
         setInternalValue(input);
@@ -113,7 +128,7 @@ const IntervalInput: React.FC<IntervalInputProps> = forwardRef(
 
     const handleFocus = () => {
       setIsFocused(true);
-      if (!internalValue.includes("-")) {
+      if (!internalValue.includes(DELIMITER)) {
         const newValue = `${internalValue}`;
         setInternalValue(newValue);
 
@@ -129,9 +144,9 @@ const IntervalInput: React.FC<IntervalInputProps> = forwardRef(
 
     const handleBlur = () => {
       setIsFocused(false);
-      // console.log(internalValue.split("-")[1]);
-      if (internalValue.includes("-") && internalValue.split("-")[1] === "") {
-        const newValue = internalValue.replace("-", "");
+      // console.log(internalValue.split(DELIMITER)[1]);
+      if (internalValue.includes(DELIMITER) && internalValue.split(DELIMITER)[1] === "") {
+        const newValue = internalValue.replace(DELIMITER, "");
         setInternalValue(newValue);
         customOnChange?.(newValue);
       }
@@ -141,10 +156,10 @@ const IntervalInput: React.FC<IntervalInputProps> = forwardRef(
       const { key } = e;
       const currentPos = inputRef.current?.selectionStart || 0;
 
-      if (key === "-") {
+      if (key === DELIMITER) {
         e.preventDefault();
-        if (internalValue.includes("-")) {
-          const dashPos = internalValue.indexOf("-");
+        if (internalValue.includes(DELIMITER)) {
+          const dashPos = internalValue.indexOf(DELIMITER);
           if (currentPos <= dashPos) {
             inputRef.current?.setSelectionRange(dashPos + 1, dashPos + 1);
           }
@@ -152,10 +167,10 @@ const IntervalInput: React.FC<IntervalInputProps> = forwardRef(
           const newValue = `${internalValue.slice(
             0,
             currentPos
-          )}-${internalValue.slice(currentPos)}`;
+          )}${DELIMITER}${internalValue.slice(currentPos)}`;
           if (validateInput(newValue)) {
             setInternalValue(newValue);
-            onChange?.(newValue);
+            customOnChange?.(newValue);
             setTimeout(() => {
               inputRef.current?.setSelectionRange(
                 currentPos + 1,

--- a/src/components/general/LevelInputNumber.tsx
+++ b/src/components/general/LevelInputNumber.tsx
@@ -1,8 +1,9 @@
 import { InputNumber, InputNumberProps } from "antd";
+import type { IntervalValue } from "../../types/types";
 
 export interface LevelValue {
   level: string;
-  value?: number | null;
+  value?: IntervalValue | null;
 }
 
 export interface LevelInputNumberProps
@@ -17,15 +18,20 @@ const LevelInputNumber: React.FC<LevelInputNumberProps> = ({
   ...rest
 }) => {
   const level = value?.level;
-  const num = value?.value;
+  const num = value?.value ? parseFloat(value.value.value) : undefined;
   const handleChange = (val: string | number | null) => {
-    const numeric =
-      typeof val === "string"
-        ? parseFloat(val)
-        : val === null
-        ? undefined
-        : val;
-    onChange?.({ level: level ?? "", value: numeric });
+    if (val === null) {
+      onChange?.({ level: level ?? "", value: undefined });
+      return;
+    }
+    const numeric = typeof val === "string" ? parseFloat(val) : val;
+    const newVal: IntervalValue = {
+      front: numeric ?? NaN,
+      rear: NaN,
+      value: String(val ?? ""),
+      unit: rest.addonAfter ? String(rest.addonAfter) : "",
+    };
+    onChange?.({ level: level ?? "", value: newVal });
   };
   return (
     <InputNumber

--- a/src/components/quoteForm/FeedblockForm/FeedblockForm.tsx
+++ b/src/components/quoteForm/FeedblockForm/FeedblockForm.tsx
@@ -292,21 +292,6 @@ const FeedblockForm = forwardRef(
                 label="每层复合比例"
                 canCreate={false}
                 canDelete={false}
-                rules={[
-                  {
-                    required: true,
-                    validator: async (_: any, value: LevelValue[]) => {
-                      const sum = value?.reduce(
-                        (t, c) => t + Number(c?.value || 0),
-                        0
-                      );
-                      if (sum !== 100) {
-                        return Promise.reject(new Error("比例和需为100%"));
-                      }
-                      return Promise.resolve();
-                    },
-                  },
-                ]}
                 isHorizontal
                 formItems={
                   <ProForm.Item
@@ -314,7 +299,8 @@ const FeedblockForm = forwardRef(
                     rules={[
                       {
                         validator: async (_: any, value: LevelValue) => {
-                          if (!value.value || value.value == 0) {
+                          const num = parseFloat(value?.value?.value || "0");
+                          if (isNaN(num) || num === 0) {
                             return Promise.reject(new Error("比例不得为0"));
                           }
                           return Promise.resolve();

--- a/src/components/quoteForm/dieForm/DieForm.tsx
+++ b/src/components/quoteForm/dieForm/DieForm.tsx
@@ -59,7 +59,7 @@ const DieForm = forwardRef(
     });
 
     const handleDieWidth = (value: string) => {
-      const width = Number(value?.split("-")[0]);
+      const width = Number(value?.split("～")[0]);
       const zone = nearestOdd(width);
       form.setFieldValue("heatingZones", zone);
       form.setFieldValue("powerCableLength", width <= 1500 ? 3 : 5);

--- a/src/components/quoteForm/formComponents/DieWidthInput.tsx
+++ b/src/components/quoteForm/formComponents/DieWidthInput.tsx
@@ -36,8 +36,8 @@ export const DieWidthInput: React.FC<CombinedWidthInputProps> = ({
     onChange?.({ ...value, widthType: type });
   };
 
-  const handleIntervalChange = (val: string) => {
-    onChange?.({ ...value, length: val });
+  const handleIntervalChange = (val: IntervalInputProps["value"]) => {
+    onChange?.({ ...value, length: val?.value });
   };
 
   return (

--- a/src/components/quoteForm/formComponents/HeatingMethodInput.tsx
+++ b/src/components/quoteForm/formComponents/HeatingMethodInput.tsx
@@ -62,7 +62,7 @@ export const HeatingMethodSelect: React.FC<HeatingMethodSelectProps> = ({
   };
 
   const isCastAluminumDisabled = temperature
-    ?.split("-")
+    ?.split("～")
     .some((temp) => Number(temp) >= 330);
 
   useEffect(() => {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -128,3 +128,10 @@ export interface FilterProduct {
   pressure: string | null;
   remark: string | null;
 }
+
+export interface IntervalValue {
+  front: number;
+  rear: number;
+  value: string;
+  unit: string;
+}

--- a/src/util/rules.ts
+++ b/src/util/rules.ts
@@ -1,5 +1,7 @@
 import { Rule } from "antd/es/form";
 
+const DELIMITER = "～";
+
 // 表单验证规则
 export const powerInputRules: Rule[] = [
   {
@@ -61,8 +63,8 @@ export const DieWidthInputRule: Rule[] = [
       }
 
       // 检查是否是范围格式
-      if (value.length.includes("-")) {
-        const parts = value.length.split("-").map((part: any) => part.trim());
+      if (value.length.includes(DELIMITER)) {
+        const parts = value.length.split(DELIMITER).map((part: any) => part.trim());
 
         // 验证两部分都是有效数字
         if (parts.some((part: any) => !/^\d+$/.test(part))) {
@@ -82,11 +84,12 @@ export const DieWidthInputRule: Rule[] = [
 ];
 export const intervalInputRules: Rule[] = [
   {
-    validator: (_: any, value) => {
-      if (!value || !value.includes("-")) {
+    validator: (_: any, value: { value?: string }) => {
+      const val = value?.value;
+      if (!val || !val.includes(DELIMITER)) {
         return Promise.resolve();
       }
-      const [first, second] = value.split("-").map(parseFloat);
+      const [first, second] = val.split(DELIMITER).map(parseFloat);
 
       if (!isNaN(first) && !isNaN(second) && first >= second) {
         return Promise.reject(new Error("第一个数字必须小于第二个数字"));
@@ -97,11 +100,12 @@ export const intervalInputRules: Rule[] = [
   },
   {
     // required: true,
-    validator: (_: any, value) => {
-      if (!value || !value.includes("-")) {
+    validator: (_: any, value: { value?: string }) => {
+      const val = value?.value;
+      if (!val || !val.includes(DELIMITER)) {
         return Promise.resolve();
       }
-      const [first, second] = value.split("-").map(parseFloat);
+      const [first, second] = val.split(DELIMITER).map(parseFloat);
 
       if (!isNaN(first) && !isNaN(second) && first <= second) {
         return Promise.reject(
@@ -116,12 +120,12 @@ export const intervalInputRules: Rule[] = [
 export const autoCompleteIntervalInputRules: Rule[] = [
   {
     // required: true,
-    validator: (_: any, value1) => {
-      const value = value1?.value;
-      if (!value || !value.includes("-")) {
+    validator: (_: any, value1: { value?: { value?: string } }) => {
+      const val = value1?.value?.value;
+      if (!val || !val.includes(DELIMITER)) {
         return Promise.resolve();
       }
-      const [first, second] = value.split("-").map(parseFloat);
+      const [first, second] = val.split(DELIMITER).map(parseFloat);
 
       if (!isNaN(first) && !isNaN(second) && first >= second) {
         return Promise.reject(new Error("第一个数字必须小于第二个数字"));


### PR DESCRIPTION
## Summary
- define `DELIMITER` as '～' for range values
- support negative numbers and new delimiter in `IntervalInput`
- adapt autocomplete interval and related forms
- update validation rules for tilde delimiter
- switch `LevelInputNumber` to use new `IntervalValue` shape
- drop validation rule on `compositeRatio` list

## Testing
- `npm run build` *(fails: Cannot find module '@wecom/jssdk')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684959a5dc008327a26e7ba7e3b5f290