### PR TITLE
Implement history and OA quote pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,8 @@ import TestComponent from "./components/test";
 import AuthCallback from "./page/AuthCallback";
 import MainLayout from "./components/MainLayout";
 import JdyRedirect from "./page/JdyRedirect";
-import QuotesPage from "./page/quote/QuoteTablePage";
+import HistoryQuoteTablePage from "./page/quote/HistoryQuoteTablePage";
+import OAQuoteTablePage from "./page/quote/OAQuoteTablePage";
 import QuoteFormPage from "./page/quote/QuoteFormPage";
 import { NoPermissionPage } from "./page/NoPermissionPage";
 
@@ -34,8 +35,12 @@ const App: React.FC = () => {
                 path="external_contact"
                 element={<ExternalContactBindingPage />}
               />
-              <Route path="quote" element={<QuotesPage />} />
-              <Route path="quote/:id" element={<QuoteFormPage />} />
+              <Route path="quote" element={<Outlet />}> 
+                <Route index element={<HistoryQuoteTablePage />} />
+                <Route path="history" element={<HistoryQuoteTablePage />} />
+                <Route path="oa" element={<OAQuoteTablePage />} />
+                <Route path=":id" element={<QuoteFormPage />} />
+              </Route>
             </Route>
             <Route path="/jdy_redirect" element={<JdyRedirect />} />
           </Route>

--- a/src/api/services/quote.service.ts
+++ b/src/api/services/quote.service.ts
@@ -45,9 +45,17 @@ export const QuoteService = {
     });
     return result.data;
   },
-  async getQuotes() {
-    const quote = await apiClient.get("/quote/get");
-    return quote.data as Quote[];
+  async getQuotes(params?: {
+    page?: number;
+    pageSize?: number;
+    type?: string;
+    quoteName?: string;
+    customerName?: string;
+  }) {
+    const quote = await apiClient.get("/quote/get", {
+      params,
+    });
+    return quote.data as { list: Quote[]; total: number };
   },
   async getQuote(quoteId: number) {
     const quote = await apiClient.get("/quote/detail/get", {

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -54,6 +54,14 @@ const MainLayout: React.FC = () => {
       icon: <HomeOutlined />,
       label: "首页",
     },
+    {
+      key: "/quote/history",
+      label: "历史报价单",
+    },
+    {
+      key: "/quote/oa",
+      label: "OA报价单",
+    },
     // {
     //   key: "/dashboard",
     //   icon: <SettingOutlined />,

--- a/src/page/quote/HistoryQuoteTablePage.tsx
+++ b/src/page/quote/HistoryQuoteTablePage.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { Typography } from "antd";
+import QuoteTable from "../../components/quote/QuoteTable";
+import { AddHistoryModal } from "../../components/quote/AddHistoryModal";
+
+const HistoryQuoteTablePage: React.FC = () => {
+  return (
+    <>
+      <Typography.Title level={3}>历史报价单</Typography.Title>
+      <AddHistoryModal />
+      <QuoteTable type="history" />
+    </>
+  );
+};
+
+export default HistoryQuoteTablePage;

--- a/src/page/quote/OAQuoteTablePage.tsx
+++ b/src/page/quote/OAQuoteTablePage.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Typography } from "antd";
+import QuoteTable from "../../components/quote/QuoteTable";
+
+const OAQuoteTablePage: React.FC = () => {
+  return (
+    <>
+      <Typography.Title level={3}>OA报价单</Typography.Title>
+      <QuoteTable type="oa" />
+    </>
+  );
+};
+
+export default OAQuoteTablePage;

--- a/src/store/useQuoteStore.ts
+++ b/src/store/useQuoteStore.ts
@@ -44,6 +44,7 @@ export interface Product {
 
 interface QuotesStore {
   quotes: Quote[];
+  total: number;
   loading: {
     add: boolean;
     delete: boolean;
@@ -55,7 +56,13 @@ interface QuotesStore {
   configModalVisible: boolean;
   setConfigModalVisible: (bool: boolean) => void;
   initialize: () => Promise<void>;
-  fetchQuotes: () => Promise<void>;
+  fetchQuotes: (params: {
+    page?: number;
+    pageSize?: number;
+    type?: string;
+    quoteName?: string;
+    customerName?: string;
+  }) => Promise<void>;
   fetchQuote: (quoteId: number) => Promise<Quote>;
   createQuote: (params: {
     customerName: string;
@@ -105,6 +112,7 @@ interface QuotesStore {
 export const useQuoteStore = create<QuotesStore>()(
   immer((set, get) => ({
     quotes: [],
+    total: 0,
     categories: [],
     loading: {
       add: false,
@@ -124,10 +132,10 @@ export const useQuoteStore = create<QuotesStore>()(
       set({ categories });
     },
 
-    fetchQuotes: async () => {
+    fetchQuotes: async (params) => {
       set({ loading: { ...get().loading, getQuotes: true } });
-      const quotes = await QuoteService.getQuotes();
-      set({ quotes });
+      const { list, total } = await QuoteService.getQuotes(params);
+      set({ quotes: list, total });
       set({ loading: { ...get().loading, getQuotes: false } });
     },
 


### PR DESCRIPTION
## Summary
- extract `QuoteTable` component with search form and local pagination
- add `HistoryQuoteTablePage` and `OAQuoteTablePage`
- update router and navigation menu for the new pages
- remove type column from table
- hide approval column on history page
- show skeleton while fetching quote details
- implement server-side pagination for quote lists

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6848648236ec8327acd423acbc9f04bc