### PR TITLE
Refactor LevelInputNumber to use IntervalInput

### DIFF
--- a/src/components/general/LevelInputNumber.tsx
+++ b/src/components/general/LevelInputNumber.tsx
@@ -1,4 +1,5 @@
-import { InputNumber, InputNumberProps } from "antd";
+import type { IntervalInputProps } from "./IntervalInput";
+import { IntervalInput } from "./IntervalInput";
 import type { IntervalValue } from "../../types/types";
 
 export interface LevelValue {
@@ -7,7 +8,7 @@ export interface LevelValue {
 }
 
 export interface LevelInputNumberProps
-  extends Omit<InputNumberProps, "value" | "onChange" | "addonBefore"> {
+  extends Omit<IntervalInputProps, "value" | "onChange" | "addonBefore" | "unit"> {
   value?: LevelValue;
   onChange?: (val: LevelValue) => void;
 }
@@ -18,26 +19,15 @@ const LevelInputNumber: React.FC<LevelInputNumberProps> = ({
   ...rest
 }) => {
   const level = value?.level;
-  const num = value?.value ? parseFloat(value.value.value) : undefined;
-  const handleChange = (val: string | number | null) => {
-    if (val === null) {
-      onChange?.({ level: level ?? "", value: undefined });
-      return;
-    }
-    const numeric = typeof val === "string" ? parseFloat(val) : val;
-    const newVal: IntervalValue = {
-      front: numeric ?? NaN,
-      rear: NaN,
-      value: String(val ?? ""),
-      unit: rest.addonAfter ? String(rest.addonAfter) : "",
-    };
-    onChange?.({ level: level ?? "", value: newVal });
+  const handleChange = (val: IntervalValue) => {
+    onChange?.({ level: level ?? "", value: val });
   };
   return (
-    <InputNumber
+    <IntervalInput
       {...rest}
       addonBefore={level}
-      value={num as any}
+      unit="%"
+      value={value?.value}
       onChange={handleChange}
     />
   );

--- a/src/components/quoteForm/FeedblockForm/FeedblockForm.tsx
+++ b/src/components/quoteForm/FeedblockForm/FeedblockForm.tsx
@@ -308,13 +308,7 @@ const FeedblockForm = forwardRef(
                       },
                     ]}
                   >
-                    <LevelInputNumber
-                      formatter={(v) => `${v}%`}
-                      parser={(v) => v?.replace(/%/g, "") as any}
-                      style={{ width: 120 }}
-                      min={0}
-                      max={100}
-                    />
+                    <LevelInputNumber style={{ width: 120 }} />
                   </ProForm.Item>
                 }
               />


### PR DESCRIPTION
## Summary
- refactor LevelInputNumber to wrap `IntervalInput`
- update Feedblock form to use new component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a6917d5c48327a984aafbcb94e8ee