### PR TITLE
Add hydraulic station form

### DIFF
--- a/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
+++ b/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
@@ -15,6 +15,7 @@ import { QuoteItem } from "../../../types/types";
 import MeteringPumpForm from "../../quoteForm/MeteringPumpForm/MeteringPumpForm";
 import FeedblockForm from "../../quoteForm/FeedblockForm/FeedblockForm";
 import FilterForm from "../../quoteForm/FilterForm/FilterForm";
+import HydraulicStationForm from "../../quoteForm/HydraulicStationForm/HydraulicStationForm";
 
 interface ProductConfigurationFormProps {
   quoteItem?: QuoteItem;
@@ -114,6 +115,16 @@ const ProductConfigurationForm = forwardRef(
         return {
           form: (
             <FilterForm
+              ref={modelFormRef}
+              quoteId={quoteId}
+              quoteItemId={quoteItem?.id ?? 0}
+            />
+          ),
+        };
+      if (category?.includes("液压站"))
+        return {
+          form: (
+            <HydraulicStationForm
               ref={modelFormRef}
               quoteId={quoteId}
               quoteItemId={quoteItem?.id ?? 0}

--- a/src/components/quoteForm/HydraulicStationForm/HydraulicStationForm.tsx
+++ b/src/components/quoteForm/HydraulicStationForm/HydraulicStationForm.tsx
@@ -1,0 +1,76 @@
+import { Col, Form, FormInstance, InputNumber, Row, Segmented, Typography } from "antd";
+import { forwardRef, useImperativeHandle } from "react";
+import ProForm from "@ant-design/pro-form";
+import { PowerInput } from "../formComponents/PowerInput";
+import { useQuoteStore } from "../../../store/useQuoteStore";
+
+interface HydraulicStationFormProps {
+  quoteId: number;
+  quoteItemId: number;
+}
+
+const HydraulicStationForm = forwardRef(({ quoteId, quoteItemId }: HydraulicStationFormProps, ref) => {
+  const [form] = Form.useForm();
+
+  useImperativeHandle(ref, () => ({
+    form,
+  }));
+
+  const quoteItems = useQuoteStore.getState().quotes.find(q => q.id === quoteId)?.items ?? [];
+  const findItemById = useQuoteStore.getState().findItemById;
+  const currentItem = findItemById(quoteItems, quoteItemId);
+  const linkedName = currentItem?.linkId ? findItemById(quoteItems, currentItem.linkId)?.productName : undefined;
+
+  return (
+    <ProForm layout="vertical" form={form} submitter={false}>
+      {linkedName && (
+        <Typography.Text type="secondary" style={{ display: 'block', marginBottom: 16 }}>
+          关联产品：{linkedName}
+        </Typography.Text>
+      )}
+      <Row gutter={16}>
+        <Col xs={12} md={6}>
+          <Form.Item label="类型" name="type" initialValue="油泵" rules={[{ required: true, message: '请选择类型' }]}> 
+            <Segmented options={["油泵", "蓄能器"]} />
+          </Form.Item>
+        </Col>
+        <Col xs={12} md={6}>
+          <Form.Item label="规格" name="spec" initialValue="电磁阀" rules={[{ required: true, message: '请选择规格' }]}> 
+            <Segmented options={["电磁阀", "手动阀"]} />
+          </Form.Item>
+        </Col>
+        <Col xs={12} md={6}>
+          <Form.Item label="阀共享数量" name="valveShare" initialValue="一" rules={[{ required: true, message: '请选择共享阀数量' }]}> 
+            <Segmented options={["一", "二", "三", "四"]} />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col xs={24} md={12}>
+          <Form.Item label="电机电压" name="powerInput" rules={[{ required: true, message: '请输入电机电压' }]}> 
+            <PowerInput />
+          </Form.Item>
+        </Col>
+        <Col xs={12} md={6}>
+          <Form.Item label="功率" name="power" rules={[{ required: true, message: '请输入功率' }]}> 
+            <InputNumber style={{ width: '100%' }} formatter={v => (v ? `${v}kw` : '')} parser={v => v?.replace(/kw/g, '') as any} />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col xs={12} md={6}>
+          <Form.Item label="油管长度" name="pipeLength" rules={[{ required: true, message: '请输入油管长度' }]}> 
+            <InputNumber style={{ width: '100%' }} addonAfter="米" min={0} />
+          </Form.Item>
+        </Col>
+        <Col xs={12} md={6}>
+          <Form.Item label="油管数量" name="pipeQuantity" rules={[{ required: true, message: '请输入油管数量' }]}> 
+            <InputNumber style={{ width: '100%' }} addonAfter="条" min={0} />
+          </Form.Item>
+        </Col>
+      </Row>
+    </ProForm>
+  );
+});
+
+export default HydraulicStationForm;


### PR DESCRIPTION
## Summary
- add hydraulic station form with voltage, power and pipe fields
- show linked product name when available
- load hydraulic station form for hydraulic station items

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react/jsx-runtime')*

------
https://chatgpt.com/codex/tasks/task_e_684a94244cc08327b069d40957395dd7