### PR TITLE
Add thickness gauge form

### DIFF
--- a/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
+++ b/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
@@ -15,6 +15,7 @@ import { QuoteItem } from "../../../types/types";
 import MeteringPumpForm from "../../quoteForm/MeteringPumpForm/MeteringPumpForm";
 import FeedblockForm from "../../quoteForm/FeedblockForm/FeedblockForm";
 import FilterForm from "../../quoteForm/FilterForm/FilterForm";
+import ThicknessGaugeForm from "../../quoteForm/ThicknessGaugeForm/ThicknessGaugeForm";
 
 interface ProductConfigurationFormProps {
   quoteItem?: QuoteItem;
@@ -71,6 +72,12 @@ const ProductConfigurationForm = forwardRef(
           return `${model}${name}`;
         }
       }
+      if (category.at(-1) === "测厚仪") {
+        const model = modelFormRef.current?.form.getFieldValue("model");
+        if (model) {
+          return `${model}测厚仪`;
+        }
+      }
       return "";
     };
 
@@ -114,6 +121,16 @@ const ProductConfigurationForm = forwardRef(
         return {
           form: (
             <FilterForm
+              ref={modelFormRef}
+              quoteId={quoteId}
+              quoteItemId={quoteItem?.id ?? 0}
+            />
+          ),
+        };
+      if (category?.at(1) == "测厚仪")
+        return {
+          form: (
+            <ThicknessGaugeForm
               ref={modelFormRef}
               quoteId={quoteId}
               quoteItemId={quoteItem?.id ?? 0}

--- a/src/components/quoteForm/ThicknessGaugeForm/ThicknessGaugeForm.tsx
+++ b/src/components/quoteForm/ThicknessGaugeForm/ThicknessGaugeForm.tsx
@@ -1,0 +1,131 @@
+import { Col, Form, Radio, Row, Segmented } from "antd";
+import ProForm from "@ant-design/pro-form";
+import { forwardRef, useImperativeHandle } from "react";
+
+const models = ["WLV3", "ULO3"];
+const types = ["手动", "自动"];
+const widths = [500, 1000, 1500, 2000, 2500, 3000, 3500];
+
+const ThicknessGaugeForm = forwardRef<any, { quoteId: number; quoteItemId: number }>(
+  (props, ref) => {
+    const [form] = Form.useForm();
+
+    useImperativeHandle(ref, () => ({
+      form,
+    }));
+
+    const handleValuesChange = (changed: any) => {
+      if (changed.model) {
+        const model = changed.model;
+        if (model === "WLV3") {
+          if (form.getFieldValue("operation") === "自动") {
+            form.setFieldValue("operation", "手动");
+          }
+          const w = form.getFieldValue("width");
+          if (w === 3000 || w === 3500) {
+            form.setFieldValue("width", undefined);
+          }
+          if (form.getFieldValue("robotControlBox")) {
+            form.setFieldValue("robotControlBox", false);
+          }
+          if (form.getFieldValue("boltControlBox")) {
+            form.setFieldValue("boltControlBox", false);
+          }
+        }
+      }
+    };
+
+    return (
+      <ProForm
+        layout="vertical"
+        form={form}
+        submitter={false}
+        onValuesChange={handleValuesChange}
+      >
+        <Row gutter={16}>
+          <Col xs={12} md={6}>
+            <Form.Item
+              name="model"
+              label="型号"
+              rules={[{ required: true, message: "请选择型号" }]}
+              initialValue="WLV3"
+            >
+              <Segmented options={models} />
+            </Form.Item>
+          </Col>
+          <Form.Item noStyle dependencies={["model"]}>
+            {({ getFieldValue }) => (
+              <Col xs={12} md={6}>
+                <Form.Item
+                  name="operation"
+                  label="控制方式"
+                  rules={[{ required: true, message: "请选择控制方式" }]}
+                  initialValue="手动"
+                >
+                  <Segmented options={getFieldValue("model") === "ULO3" ? types : ["手动"]} />
+                </Form.Item>
+              </Col>
+            )}
+          </Form.Item>
+          <Form.Item noStyle dependencies={["model"]}>
+            {({ getFieldValue }) => {
+              const model = getFieldValue("model");
+              const opts = widths
+                .filter((w) => model === "ULO3" || w <= 2500)
+                .map((w) => ({ label: w.toString(), value: w }));
+              return (
+                <Col xs={12} md={6}>
+                  <Form.Item
+                    name="width"
+                    label="适用宽度(mm)"
+                    rules={[{ required: true, message: "请选择适用宽度" }]}
+                  >
+                    <Segmented options={opts} />
+                  </Form.Item>
+                </Col>
+              );
+            }}
+          </Form.Item>
+          <Form.Item noStyle dependencies={["model"]}>
+            {({ getFieldValue }) => (
+              <>
+                <Col xs={12} md={6}>
+                  <Form.Item
+                    name="robotControlBox"
+                    label="选配机械臂控制盒"
+                    rules={[{ required: true, message: "是否选配机械臂控制盒" }]}
+                    initialValue={false}
+                  >
+                    <Radio.Group>
+                      <Radio value={true} disabled={getFieldValue("model") !== "ULO3"}>
+                        是
+                      </Radio>
+                      <Radio value={false}>否</Radio>
+                    </Radio.Group>
+                  </Form.Item>
+                </Col>
+                <Col xs={12} md={6}>
+                  <Form.Item
+                    name="boltControlBox"
+                    label="选配全马达螺栓控制盒"
+                    rules={[{ required: true, message: "是否选配全马达螺栓控制盒" }]}
+                    initialValue={false}
+                  >
+                    <Radio.Group>
+                      <Radio value={true} disabled={getFieldValue("model") !== "ULO3"}>
+                        是
+                      </Radio>
+                      <Radio value={false}>否</Radio>
+                    </Radio.Group>
+                  </Form.Item>
+                </Col>
+              </>
+            )}
+          </Form.Item>
+        </Row>
+      </ProForm>
+    );
+  }
+);
+
+export default ThicknessGaugeForm;


### PR DESCRIPTION
## Summary
- add new `ThicknessGaugeForm` component with model-specific options
- integrate thickness gauge form into product configuration selection
- generate name logic for thickness gauge

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a97a947308327ba1a82a10d38ba82