### PR TITLE
Implement single select final product field

### DIFF
--- a/src/api/services/customer.service.ts
+++ b/src/api/services/customer.service.ts
@@ -26,6 +26,12 @@ export const CustomerService = {
     });
     return res.data;
   },
+  async getContacts(id: string) {
+    const res = await apiClient.get("/customer/contact/get", {
+      params: { id },
+    });
+    return res.data as { contacts: any[]; address: any };
+  },
   async matchCustomer(payload: {
     externalUserId: string;
     corpName: string;

--- a/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
+++ b/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
@@ -22,7 +22,7 @@ interface ProductConfigurationFormProps {
   quoteItem?: QuoteItem;
   quoteId: number;
   material?: string[];
-  finalProduct?: string[];
+  finalProduct?: string;
   style?: any;
 }
 const ProductConfigurationForm = forwardRef(
@@ -31,7 +31,7 @@ const ProductConfigurationForm = forwardRef(
       quoteItem,
       quoteId,
       material = [],
-      finalProduct = [],
+      finalProduct = "",
       style,
     }: ProductConfigurationFormProps,
     ref
@@ -47,7 +47,7 @@ const ProductConfigurationForm = forwardRef(
 
       if (category[0] === "平模") {
         const mat = material.join("");
-        const final = finalProduct.join("");
+        const final = finalProduct;
         return `${mat}${final}模头`;
       }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -46,7 +46,7 @@ export interface Quote {
   opportunityId?: string;
   opportunityName?: string; // opportunityName
   material: string[]; // 适用原料
-  finalProduct: string[]; // 最终产品
+  finalProduct: string; // 最终产品
   applicationField: string[]; // 应用领域
   currencyType: string; // 货币类型
   customerName: string; // 客户名称
@@ -62,6 +62,8 @@ export interface Quote {
   address: any; // 地址
   contactName: string; // 联系人姓名
   contactPhone: string; // 联系人手机号
+  telephone?: string; // 电话
+  faxNumber?: string; // 传真号
   technicalLevel: string; // 技术等级
   projectLevel: string; // 项目等级
   flowState: string; // 报价状态


### PR DESCRIPTION
## Summary
- switch final product input to grouped AutoComplete
- remove unused TagAutoComplete component
- update Quote type and configuration forms for new finalProduct string
- tweak flat die name generation logic

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ab3a70184832791794c2ff462e0bc