### PR TITLE
Add gift totals to config

### DIFF
--- a/src/components/quote/ProductConfigForm/ProductConfigModal.tsx
+++ b/src/components/quote/ProductConfigForm/ProductConfigModal.tsx
@@ -110,6 +110,18 @@ const ProductConfigModal: React.FC<ProductConfigModalProps> = ({
       errors?.every((err) => err.errors.length == 0) &&
       priceErrors?.every((err) => err.errors.length == 0);
     const values = form?.getFieldsValue();
+    if (values?.gifts && Array.isArray(values.gifts)) {
+      values.gifts = values.gifts.map((g: any) => {
+        const q = Number(g?.quantity) || 0;
+        const p = Number(g?.unitPrice) || 0;
+        const subtotal = q && p ? q * p : 0;
+        return { ...g, subtotal };
+      });
+      values.giftsTotal = values.gifts.reduce(
+        (sum: number, g: any) => sum + (g.subtotal || 0),
+        0
+      );
+    }
     const price = priceForm?.getFieldsValue();
     const config = { ...values };
     if (quoteItem?.id) {

--- a/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
+++ b/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
@@ -17,6 +17,7 @@ import FeedblockForm from "../../quoteForm/FeedblockForm/FeedblockForm";
 import FilterForm from "../../quoteForm/FilterForm/FilterForm";
 import ThicknessGaugeForm from "../../quoteForm/ThicknessGaugeForm/ThicknessGaugeForm";
 import HydraulicStationForm from "../../quoteForm/HydraulicStationForm/HydraulicStationForm";
+import GiftForm from "../../quoteForm/GiftForm";
 
 interface ProductConfigurationFormProps {
   quoteItem?: QuoteItem;
@@ -176,6 +177,10 @@ const ProductConfigurationForm = forwardRef(
           ),
         };
 
+      if (category?.[0] === "赠品")
+        return {
+          form: (<GiftForm ref={modelFormRef} />),
+        };
       return {
         form: <OtherForm ref={modelFormRef} />,
       };

--- a/src/components/quoteForm/GiftForm.tsx
+++ b/src/components/quoteForm/GiftForm.tsx
@@ -1,0 +1,102 @@
+import { AutoComplete, Col, Form, FormInstance, InputNumber, Row, Select, Typography } from "antd";
+import ProForm, { ProFormList, ProFormDependency } from "@ant-design/pro-form";
+import { forwardRef, useImperativeHandle } from "react";
+import { formatPrice } from "../../util/valueUtil";
+
+interface GiftFormRef {
+  form: FormInstance;
+}
+
+const GiftForm = forwardRef<GiftFormRef>((props, ref) => {
+  const [form] = Form.useForm();
+
+  useImperativeHandle(ref, () => ({
+    form,
+  }));
+
+  return (
+    <ProForm layout="vertical" form={form} submitter={false}>
+      <ProFormList
+        name="gifts"
+        label="赠品明细"
+        creatorButtonProps={{ creatorButtonText: "新增赠品" }}
+      >
+        {(f, index, action) => (
+          <Row gutter={16}>
+            <Col xs={24} md={5}>
+              <Form.Item
+                name="name"
+                label="赠品名称"
+                rules={[{ required: true, message: "请输入赠品名称" }]}
+              >
+                <AutoComplete options={[]} placeholder="赠品名称" />
+              </Form.Item>
+            </Col>
+            <Col xs={12} md={4}>
+              <Form.Item
+                name="quantity"
+                label="数量"
+                rules={[{ required: true, message: "请输入数量" }]}
+                initialValue={1}
+              >
+                <InputNumber min={1} style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+            <Col xs={12} md={4}>
+              <Form.Item
+                name="unit"
+                label="单位"
+                rules={[{ required: true, message: "请选择单位" }]}
+                initialValue="件"
+              >
+                <Select style={{ width: "100%" }}>
+                  <Select.Option value="件">件</Select.Option>
+                  <Select.Option value="套">套</Select.Option>
+                  <Select.Option value="个">个</Select.Option>
+                </Select>
+              </Form.Item>
+            </Col>
+            <Col xs={12} md={5}>
+              <Form.Item
+                name="unitPrice"
+                label="单价"
+                rules={[{ required: true, message: "请输入单价" }]}
+              >
+                <InputNumber min={0} precision={2} style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+            <Col xs={12} md={6}>
+              <ProFormDependency name={["quantity", "unitPrice"]}>
+                {({ quantity, unitPrice }) => (
+                  <Form.Item label="合计">
+                    <Typography.Text strong>
+                      {quantity && unitPrice ? `¥ ${formatPrice(quantity * unitPrice)}` : 0}
+                    </Typography.Text>
+                  </Form.Item>
+                )}
+              </ProFormDependency>
+            </Col>
+          </Row>
+        )}
+      </ProFormList>
+      <Form.Item shouldUpdate>
+        {({ getFieldValue }) => {
+          const gifts = getFieldValue("gifts") || [];
+          const total = gifts.reduce((sum: number, g: any) => {
+            const q = g?.quantity;
+            const p = g?.unitPrice;
+            if (q && p) return sum + q * p;
+            return sum;
+          }, 0);
+          return (
+            <Typography.Text strong>
+              总计：¥ {formatPrice(total || 0)}
+            </Typography.Text>
+          );
+        }}
+      </Form.Item>
+    </ProForm>
+  );
+});
+
+export default GiftForm;


### PR DESCRIPTION
## Summary
- compute subtotal and total for gifts when saving configuration

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ab5b455a88327b39af521ca9c2b66