### PR TITLE
Fix terms table inline editing

### DIFF
--- a/src/components/general/SortableTable.tsx
+++ b/src/components/general/SortableTable.tsx
@@ -94,7 +94,7 @@ export function SortableTable<
   T extends {
     id: UniqueIdentifier;
     index?: number;
-    parentId: number | undefined;
+    parentId?: number | undefined;
   }
 >({
   dataSource = [],

--- a/src/components/quote/TermsTable.tsx
+++ b/src/components/quote/TermsTable.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
-import { Button, Modal, Input } from "antd";
-import { EditOutlined, DeleteOutlined } from "@ant-design/icons";
-import SortableTable from "../general/SortableTable";
+import { Button, Input } from "antd";
+import { EditOutlined, DeleteOutlined, PlusOutlined } from "@ant-design/icons";
+import SortableTable, { DragHandle } from "../general/SortableTable";
 import { Clause } from "../../types/types";
 
 interface TermsTableProps {
@@ -15,8 +15,9 @@ const TermsTable: React.FC<TermsTableProps> = ({ value, onChange }) => {
   useEffect(() => {
     setData(value);
   }, [value]);
-  const [editing, setEditing] = useState<Clause | null>(null);
-  const [text, setText] = useState("");
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editingTitle, setEditingTitle] = useState("");
+  const [editingContent, setEditingContent] = useState("");
 
   const triggerChange = (list: Clause[]) => {
     setData(list);
@@ -32,40 +33,99 @@ const TermsTable: React.FC<TermsTableProps> = ({ value, onChange }) => {
   };
 
   const handleEdit = (record: Clause) => {
-    setEditing(record);
-    setText(record.content);
+    setEditingId(record.id);
+    setEditingTitle(record.title);
+    setEditingContent(record.content);
   };
 
   const saveEdit = () => {
-    if (!editing) return;
+    if (editingId === null) return;
     const newData = data.map((item) =>
-      item.id === editing.id ? { ...item, content: text } : item
+      item.id === editingId
+        ? { ...item, title: editingTitle, content: editingContent }
+        : item
     );
     triggerChange(newData);
-    setEditing(null);
+    setEditingId(null);
+  };
+
+  const handleAdd = () => {
+    const newId = data.length > 0 ? Math.max(...data.map((d) => d.id)) + 1 : 1;
+    const newClause: Clause = { id: newId, title: "", content: "" };
+    const newData = [...data, newClause];
+    triggerChange(newData);
+    setEditingId(newId);
+    setEditingTitle("");
+    setEditingContent("");
   };
 
   const columns = [
-    { title: "条约标题", dataIndex: "title", width: "30%" },
-    { title: "条约内容", dataIndex: "content" },
+    {
+      width: 30,
+      render: () => <DragHandle />,
+    },
+    {
+      title: "顺序",
+      dataIndex: "index",
+      width: 60,
+      render: (_: any, record: Clause, index: number) => record.index ?? index + 1,
+    },
+    {
+      title: "条约标题",
+      dataIndex: "title",
+      width: "30%",
+      render: (_: any, record: Clause) =>
+        editingId === record.id ? (
+          <Input
+            value={editingTitle}
+            onChange={(e) => setEditingTitle(e.target.value)}
+          />
+        ) : (
+          record.title
+        ),
+    },
+    {
+      title: "条约内容",
+      dataIndex: "content",
+      render: (_: any, record: Clause) =>
+        editingId === record.id ? (
+          <Input.TextArea
+            autoSize
+            value={editingContent}
+            onChange={(e) => setEditingContent(e.target.value)}
+          />
+        ) : (
+          record.content
+        ),
+    },
     {
       title: "操作",
-      width: 80,
-      render: (_: any, record: Clause) => (
-        <>
-          <Button
-            type="text"
-            icon={<EditOutlined />}
-            onClick={() => handleEdit(record)}
-          />
-          <Button
-            type="text"
-            danger
-            icon={<DeleteOutlined />}
-            onClick={() => handleDelete(record.id)}
-          />
-        </>
-      ),
+      width: 120,
+      render: (_: any, record: Clause) =>
+        editingId === record.id ? (
+          <>
+            <Button type="link" onClick={saveEdit}>
+              保存
+            </Button>
+            <Button type="link" onClick={() => setEditingId(null)}>
+              取消
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button
+              type="text"
+              icon={<EditOutlined />}
+              onClick={() => handleEdit(record)}
+            />
+            <Button
+              type="text"
+              danger
+              icon={<DeleteOutlined />}
+              onClick={() => handleDelete(record.id)}
+            />
+          </>
+        ),
     },
   ];
 
@@ -77,18 +137,15 @@ const TermsTable: React.FC<TermsTableProps> = ({ value, onChange }) => {
         onDragEnd={handleDragEnd}
         pagination={false}
       />
-      <Modal
-        open={!!editing}
-        title="编辑条约内容"
-        onOk={saveEdit}
-        onCancel={() => setEditing(null)}
+      <Button
+        type="dashed"
+        block
+        icon={<PlusOutlined />}
+        onClick={handleAdd}
+        style={{ marginTop: 8 }}
       >
-        <Input.TextArea
-          rows={4}
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-        />
-      </Modal>
+        新增条约
+      </Button>
     </>
   );
 };


### PR DESCRIPTION
## Summary
- relax generic constraint for `SortableTable`
- enable inline edit and add clause capability for `TermsTable`
- add drag handle and index columns to `TermsTable`

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ada1f5b5c8327a53c40c4e8029ea5