### PR TITLE
Fix dirty state reset when dismissing config

### DIFF
--- a/src/components/quote/QuoteModal.tsx
+++ b/src/components/quote/QuoteModal.tsx
@@ -23,7 +23,7 @@ const QuoteModal: React.FC<QuoteModalProps> = ({
   onSubmit,
 }) => {
   const { message } = App.useApp();
-  const { isQuoteDirty, saveQuote } = useQuoteStore();
+  const { isQuoteDirty, saveQuote, discardQuoteChanges } = useQuoteStore();
   const [form] = Form.useForm();
   const [isFullscreen, setIsFullscreen] = useState(false);
 
@@ -52,6 +52,7 @@ const QuoteModal: React.FC<QuoteModalProps> = ({
           onCancel();
         },
         onCancel: () => {
+          discardQuoteChanges(id);
           onCancel();
         },
       });

--- a/src/store/useQuoteStore.ts
+++ b/src/store/useQuoteStore.ts
@@ -108,6 +108,7 @@ interface QuotesStore {
   calculateItemPrice: (item: QuoteItem) => void;
   dirtyQuotes: Record<number, boolean>;
   isQuoteDirty: (quoteId: number) => boolean;
+  discardQuoteChanges: (quoteId: number) => void;
   // calculateQuoteTotal: (quoteId: number) => void;
 }
 
@@ -132,6 +133,12 @@ export const useQuoteStore = create<QuotesStore>()(
 
     isQuoteDirty: (quoteId) => {
       return !!get().dirtyQuotes[quoteId];
+    },
+
+    discardQuoteChanges: (quoteId) => {
+      set((state) => {
+        state.dirtyQuotes[quoteId] = false;
+      });
     },
 
     initialize: async () => {


### PR DESCRIPTION
## Summary
- reset dirty flag when discarding quote changes
- clear dirty status when the user chooses not to save

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_684b2213dbac8327be8d7982d2066070