### PR TITLE
Rename quote PDF fields

### DIFF
--- a/src/api/services/quote.service.ts
+++ b/src/api/services/quote.service.ts
@@ -2,6 +2,7 @@
 import { redirect } from "react-router-dom";
 import { apiClient } from "../http/client";
 import { Quote, QuoteItem } from "../../types/types";
+import axios from "axios";
 
 export const QuoteService = {
   async createQuote(params: {
@@ -62,5 +63,21 @@ export const QuoteService = {
       params: { quoteId },
     });
     return quote.data;
+  },
+  async executePrint(quote: Quote) {
+    const result = await axios.post(
+      "http://122.226.146.110:777/Contract/Execute",
+      quote
+    );
+    const data = result.data as {
+      productQuotation: string;
+      productPurchase: string;
+      productConfiguration: string;
+    };
+    return {
+      quotationPdf: data.productQuotation,
+      contractPdf: data.productPurchase,
+      configPdf: data.productConfiguration,
+    };
   },
 };

--- a/src/components/quote/QuoteForm.tsx
+++ b/src/components/quote/QuoteForm.tsx
@@ -1,6 +1,6 @@
 // components/quote/QuoteForm.tsx
 import React, { useState, useEffect, useRef } from "react";
-import { Form, Button, Tabs, App, Row, Col } from "antd";
+import { Form, Button, Tabs, App, Row, Col, Dropdown, MenuProps } from "antd";
 import { Quote, Clause } from "../../types/types";
 import QuoteConfigTab from "./QuoteConfigTab";
 import QuoteTermsTab from "./QuoteTermsTab";
@@ -146,7 +146,7 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
   isModal = false,
 }) => {
   const { message } = App.useApp();
-  const { updateQuote, saveQuote, isQuoteDirty } = useQuoteStore();
+  const { updateQuote, saveQuote, isQuoteDirty, fetchPrintUrls } = useQuoteStore();
   const [saveLoading, setSaveLoading] = useState(false);
   const [submitLoading, setSubmitLoading] = useState(false);
   const [contacts, setContacts] = useState<any[]>([]);
@@ -254,6 +254,17 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
     }
   };
 
+  const print = async (type: "config" | "quote" | "contract") => {
+    if (!quote?.id) return;
+    await fetchPrintUrls(quote.id);
+    const q = useQuoteStore.getState().quotes.find((i) => i.id === quote.id);
+    let url = "";
+    if (type === "config") url = q?.configPdf ?? "";
+    if (type === "quote") url = q?.quotationPdf ?? "";
+    if (type === "contract") url = q?.contractPdf ?? "";
+    if (url) window.open(url, "_blank");
+  };
+
   const save = throttle(
     async () => {
       setSaveLoading(true);
@@ -339,8 +350,22 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
         ]}
       />
 
-      <Row>
-        <Col span={24} style={{ textAlign: "right" }}>
+      <Row justify="space-between">
+        <Col>
+          <Dropdown.Button
+            onClick={({ key }) => print(key as any)}
+            menu={{
+              items: [
+                { key: "config", label: "配置表" },
+                { key: "quote", label: "报价" },
+                { key: "contract", label: "合同" },
+              ],
+            }}
+          >
+            打印
+          </Dropdown.Button>
+        </Col>
+        <Col style={{ textAlign: "right" }}>
           <Button
             type="primary"
             htmlType="submit"

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -79,6 +79,9 @@ export interface Quote {
   quoteTime: Date | null; // 报价时间
   quoteTerms: Clause[];
   contractTerms: Clause[];
+  quotationPdf?: string; // 报价单打印链接
+  contractPdf?: string; // 合同打印链接
+  configPdf?: string; // 配置表打印链接
   items: QuoteItem[];
   status: "draft" | "completed" | "locked";
 }


### PR DESCRIPTION
## Summary
- rename PDF URLs on `Quote`
- map API response to new field names
- use updated field names in the store and print action

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: errors in TypeScript build)*

------
https://chatgpt.com/codex/tasks/task_e_684bac2934c88327a79adf855acc0274