### PR TITLE
Update dieForm composite ratio and thermocouple

### DIFF
--- a/src/components/quoteForm/dieForm/DieForm.tsx
+++ b/src/components/quoteForm/dieForm/DieForm.tsx
@@ -10,6 +10,7 @@ import ProForm from "@ant-design/pro-form";
 import TextArea from "antd/es/input/TextArea";
 import useProductActionModal from "../../../hook/showProductActionModal";
 import { useQuoteStore } from "../../../store/useQuoteStore";
+import { LevelValue } from "../../general/LevelInputNumber";
 interface PriceFormRef {
   form: FormInstance; // 明确定义暴露的form实例
 }
@@ -73,6 +74,15 @@ const DieForm = forwardRef(
     const handleCompositeStructure = (value: string) => {
       const list = value.split("").map((s: any) => ({ layer: s }));
       form.setFieldValue("screwList", list);
+
+      const ratioList = (form.getFieldValue("compositeRatio") || []) as LevelValue[];
+      const base = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+      const len = value.length;
+      const ratioNext = Array.from({ length: len }, (_, i) => ({ level: base[i] }));
+      form.setFieldValue(
+        "compositeRatio",
+        ratioList.slice(0, len).concat(ratioNext.slice(ratioList.length))
+      );
     };
 
     const handleHasCart = async (value: string) => {

--- a/src/components/quoteForm/dieForm/Product.tsx
+++ b/src/components/quoteForm/dieForm/Product.tsx
@@ -4,7 +4,8 @@ import { IntervalInputFormItem } from "../../general/IntervalInput";
 import { CustomSelect } from "../../general/CustomSelect";
 import ScrewForm from "../formComponents/ScrewForm";
 import AutoSlashInput from "../../general/AutoSlashInput";
-import RatioInput from "../../general/RatioInput";
+import ProFormListWrapper from "../formComponents/ProFormListWrapper";
+import LevelInputNumber, { LevelValue } from "../../general/LevelInputNumber";
 import MaterialSelect from "../../general/MaterialSelect";
 
 const RUNNER_NUMBER_OPTIONS = {
@@ -170,31 +171,47 @@ export const Product = () => {
                       <AutoSlashInput />
                     </Form.Item>
                   </Col>
-                  <Col xs={12} md={6}>
+                  <Col xs={24} md={24}>
                     <ProFormDependency name={["compositeStructure"]}>
                       {({ compositeStructure }) => (
-                        <Form.Item
+                        <ProFormListWrapper
                           name="compositeRatio"
-                          label="复合比例"
-                          rules={[
-                            { required: true, message: "请输入复合比例" },
-                            {
-                              validator: (_, value) => {
-                                const length1 = value?.split(":").length;
-                                const length2 =
-                                  compositeStructure?.split("").length;
-                                if (length1 != length2) {
-                                  return Promise.reject(
-                                    new Error("复合比例与复合结构数量不匹配")
-                                  );
-                                }
-                                return Promise.resolve();
-                              },
-                            },
-                          ]}
-                        >
-                          <RatioInput />
-                        </Form.Item>
+                          label="每层复合比例"
+                          canCreate={false}
+                          canDelete={false}
+                          isHorizontal
+                          formItems={
+                            <ProForm.Item
+                              name={[]}
+                              rules={[
+                                {
+                                  validator: async (_: any, value: LevelValue) => {
+                                    const num = parseFloat(value?.value?.value || "0");
+                                    if (isNaN(num) || num === 0) {
+                                      return Promise.reject(new Error("比例不得为0"));
+                                    }
+                                    if (
+                                      (value?.value?.front && value?.value?.front >= 100) ||
+                                      (value?.value?.rear && value?.value?.rear >= 100)
+                                    ) {
+                                      return Promise.reject(new Error("比例不得超过100"));
+                                    }
+                                    if (
+                                      value?.value?.front &&
+                                      value?.value?.rear &&
+                                      value?.value?.front >= value?.value?.rear
+                                    ) {
+                                      return Promise.reject(new Error("第一个应比第二个小"));
+                                    }
+                                    return Promise.resolve();
+                                  },
+                                },
+                              ]}
+                            >
+                              <LevelInputNumber style={{ width: 120 }} />
+                            </ProForm.Item>
+                          }
+                        />
                       )}
                     </ProFormDependency>
                   </Col>

--- a/src/components/quoteForm/dieForm/TemperatureControl.tsx
+++ b/src/components/quoteForm/dieForm/TemperatureControl.tsx
@@ -95,9 +95,24 @@ export const TemperatureControl = () => {
             label="热电偶孔"
             rules={[{ required: true, message: "请选择热电偶控位" }]}
           >
-            <Checkbox.Group options={["上模", "下模"]} />
+            <Checkbox.Group options={["上模", "下模", "自定义"]} />
           </Form.Item>
         </Col>
+        <Form.Item noStyle dependencies={["thermocoupleHoles"]}>
+          {({ getFieldValue }) =>
+            getFieldValue("thermocoupleHoles")?.includes("自定义") ? (
+              <Col xs={12} sm={12}>
+                <Form.Item
+                  name="customThermocoupleHoles"
+                  label="自定义热电偶孔"
+                  rules={[{ required: true, message: "请输入自定义热电偶孔" }]}
+                >
+                  <Input />
+                </Form.Item>
+              </Col>
+            ) : null
+          }
+        </Form.Item>
         <Col xs={12} sm={12}>
           {/* 玻璃测温孔 */}
           <Form.Item


### PR DESCRIPTION
## Summary
- adjust composite ratio input in `dieForm` to align with Feedblock form
- allow custom thermocouple holes with an extra input
- sync composite ratio list with the composite structure

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684bd802a6588327bb55ed5e87f9da36