### PR TITLE
Implement auto-open and table updates

### DIFF
--- a/src/components/quote/AddHistoryModal.tsx
+++ b/src/components/quote/AddHistoryModal.tsx
@@ -3,12 +3,14 @@ import { CustomerService } from "../../api/services/customer.service";
 import CompanySearchSelect from "../general/CompanySearchSelect";
 import { useQuoteStore } from "../../store/useQuoteStore";
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import MemberSelect from "../general/MemberSelect";
 import dayjs from "dayjs";
 
 export const AddHistoryModal = () => {
   // 处理提交历史报价单
   const { message } = App.useApp();
+  const navigate = useNavigate();
   const [form] = Form.useForm();
   const { createQuote } = useQuoteStore();
   const [modalVisible, setModalVisible] = useState(false);
@@ -16,7 +18,7 @@ export const AddHistoryModal = () => {
     try {
       const values = await form.validateFields();
       setModalVisible(false);
-      await createQuote({
+      const quote = await createQuote({
         ...values,
         orderId: values.orderId,
         quoteId: values.quoteId,
@@ -29,6 +31,9 @@ export const AddHistoryModal = () => {
       });
       message.success("历史报价单添加成功");
       form.resetFields();
+      if (quote?.id) {
+        navigate(`/quote/${quote.id}`);
+      }
     } catch (error: any) {
       if (
         error?.response?.data?.message &&

--- a/src/components/quote/QuoteTable.tsx
+++ b/src/components/quote/QuoteTable.tsx
@@ -12,6 +12,7 @@ interface QuoteTableProps {
 interface QuoteTableItem {
   key: number;
   quoteId: string;
+  orderId: string;
   customerName: string;
   quoteTime: Date;
   status: string;
@@ -20,6 +21,8 @@ interface QuoteTableItem {
   salesSupportId: string;
   quoteName: string;
   projectManagerId: string;
+  creatorId: string;
+  createdAt: string;
 }
 
 const QuoteTable: React.FC<QuoteTableProps> = ({ type }) => {
@@ -85,11 +88,18 @@ const QuoteTable: React.FC<QuoteTableProps> = ({ type }) => {
 
   const columns: ColumnsType<QuoteTableItem> = [
     {
-      title: "ID",
+      title: "报价编号",
       dataIndex: "quoteId",
       key: "quoteId",
       width: 80,
       sorter: (a, b) => a.quoteId.localeCompare(b.quoteId),
+    },
+    {
+      title: "订单编号",
+      dataIndex: "orderId",
+      key: "orderId",
+      width: 80,
+      sorter: (a, b) => (a.orderId || "").localeCompare(b.orderId || ""),
     },
     {
       title: "报价名称",
@@ -113,6 +123,15 @@ const QuoteTable: React.FC<QuoteTableProps> = ({ type }) => {
       sorter: (a, b) =>
         new Date(a.quoteTime).getTime() - new Date(b.quoteTime).getTime(),
       render: (date: Date) => new Date(date).toLocaleDateString(),
+    },
+    {
+      title: "创建日期",
+      dataIndex: "createdAt",
+      key: "createdAt",
+      width: 120,
+      sorter: (a, b) =>
+        new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+      render: (date: string) => new Date(date).toLocaleDateString(),
     },
     {
       title: "当前状态",
@@ -184,21 +203,32 @@ const QuoteTable: React.FC<QuoteTableProps> = ({ type }) => {
       render: (salesSupportId: string) =>
         (salesSupportId && <MemberAvatar id={salesSupportId} />) || "-",
     },
+    {
+      title: "创建人",
+      dataIndex: "creatorId",
+      key: "creatorId",
+      width: 120,
+      render: (creatorId: string) =>
+        (creatorId && <MemberAvatar id={creatorId} />) || "-",
+    },
   ];
 
   const tableData = useMemo(
     () =>
       quotes.map((quote) => ({
         key: quote.id,
-        quoteId: (quote.quoteId || quote.orderId) ?? "",
+        quoteId: quote.quoteId ?? "",
+        orderId: quote.orderId ?? "",
         customerName: quote.customerName,
         quoteTime: quote.quoteTime as any,
+        createdAt: (quote as any).createdAt ?? "",
         status: quote.status,
         flowState: quote.flowState,
         chargerId: quote.chargerId,
         salesSupportId: quote.salesSupportId,
         quoteName: quote.quoteName,
         projectManagerId: quote.projectManagerId,
+        creatorId: quote.creatorId,
       })),
     [quotes]
   );

--- a/src/store/useQuoteStore.ts
+++ b/src/store/useQuoteStore.ts
@@ -187,6 +187,7 @@ export const useQuoteStore = create<QuotesStore>()(
       set((state) => {
         state.quotes.push(quote);
       });
+      return quote;
     },
 
     updateQuote: async (quoteId, updateData) => {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -77,6 +77,7 @@ export interface Quote {
   currentApprovalNode: string; // 当前审批节点
   currentApprover: string; // 当前审批人
   quoteTime: Date | null; // 报价时间
+  createdAt?: string; // 创建日期
   quoteTerms: Clause[];
   contractTerms: Clause[];
   quotationPdf?: string; // 报价单打印链接


### PR DESCRIPTION
## Summary
- open the newly added history quote in its form page
- return created quote from store
- show quote id, order id, creator and created date in quote table

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684be49ea3f08327ba897401c0eccbc4