### PR TITLE
Add sorting and precise timestamps

### DIFF
--- a/src/components/quote/QuoteTable.tsx
+++ b/src/components/quote/QuoteTable.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import dayjs from "dayjs";
 import { Table, Tag, Form, Input } from "antd";
 import type { ColumnsType, TablePaginationConfig } from "antd/es/table";
 import MemberAvatar from "../general/MemberAvatar";
@@ -128,10 +129,10 @@ const QuoteTable: React.FC<QuoteTableProps> = ({ type }) => {
       title: "创建日期",
       dataIndex: "createdAt",
       key: "createdAt",
-      width: 120,
+      width: 180,
       sorter: (a, b) =>
         new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
-      render: (date: string) => new Date(date).toLocaleDateString(),
+      render: (date: string) => dayjs(date).format("YYYY-MM-DD HH:mm:ss"),
     },
     {
       title: "当前状态",
@@ -208,6 +209,7 @@ const QuoteTable: React.FC<QuoteTableProps> = ({ type }) => {
       dataIndex: "creatorId",
       key: "creatorId",
       width: 120,
+      sorter: (a, b) => a.creatorId.localeCompare(b.creatorId),
       render: (creatorId: string) =>
         (creatorId && <MemberAvatar id={creatorId} />) || "-",
     },


### PR DESCRIPTION
## Summary
- sort quote tables by creator ID
- show seconds in created time values

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_684be96ce1d083279aeb9ed3eb38d878