### PR TITLE
Refine width validation for product form

### DIFF
--- a/src/components/quoteForm/dieForm/Product.tsx
+++ b/src/components/quoteForm/dieForm/Product.tsx
@@ -53,17 +53,42 @@ export const Product = () => {
             <IntervalInputFormItem
               name="productWidth"
               label="制品宽度(mm)"
-              // rules={[{ required: true, message: "请输入有效厚度范围" }]}
+              dependencies={["dieWidth"]}
+              rules={[
+                {
+                  validator: (_, value) => {
+                    const other = form.getFieldValue("dieWidth");
+                    if (!value?.value && !other?.value) {
+                      return Promise.reject(
+                        new Error("口模有效宽度和制品宽度至少要填一个")
+                      );
+                    }
+                    return Promise.resolve();
+                  },
+                },
+              ]}
               placeholder={"制品宽度"}
               unit="mm"
-              // unit="mm"
             />
           </Col>
           <Col xs={12} md={6}>
             <IntervalInputFormItem
               name="dieWidth"
               label="口模有效宽度(mm)"
-              rules={[{ required: true, message: "请输入有效宽度范围" }]}
+              dependencies={["productWidth"]}
+              rules={[
+                {
+                  validator: (_, value) => {
+                    const other = form.getFieldValue("productWidth");
+                    if (!value?.value && !other?.value) {
+                      return Promise.reject(
+                        new Error("口模有效宽度和制品宽度至少要填一个")
+                      );
+                    }
+                    return Promise.resolve();
+                  },
+                },
+              ]}
               placeholder={"有效宽度"}
               unit="mm"
               // addonAfter="mm"

--- a/src/components/quoteForm/dieForm/SurfaceTreatment.tsx
+++ b/src/components/quoteForm/dieForm/SurfaceTreatment.tsx
@@ -6,7 +6,6 @@ import {
 } from "../../../util/rules";
 import { RadioWithInput } from "../../general/RadioWithInput";
 import { AutoCompleteIntervalInput } from "../../general/AutoCompleteIntervalInput";
-import { useState } from "react";
 import TextArea from "antd/es/input/TextArea";
 import { IntervalInput1 } from "../../general/IntervalInput1";
 
@@ -70,7 +69,6 @@ const PLATING_REQUIREMENT = [
 ];
 
 export const SurfaceTreatment = () => {
-  const [precisionLevel, setPrecisionLevel] = useState<string>("S");
   return (
     <ProCard
       title="表面处理"
@@ -86,70 +84,90 @@ export const SurfaceTreatment = () => {
               options={precisionLevelOptions}
               optionType="button"
               buttonStyle="solid"
-              onChange={(e) => setPrecisionLevel(e.target.value)}
             />
           </Form.Item>
         </Col>
-        <Col xs={24} sm={12}>
-          {/* 模唇流面抛光精度 */}
-          <Form.Item
-            label="模唇流面抛光精度"
-            name="lipSurfacePrecision"
-            rules={[
-              { required: true, message: "请选择或输入抛光精度" },
-              ...autoCompleteIntervalInputRules,
-            ]}
-          >
-            <AutoCompleteIntervalInput
-              options={precisionOptions.lipSurface}
-              disabled={precisionLevel !== "custom"}
-              level={precisionLevel}
-              addonAfter={"μm"}
-            />
-          </Form.Item>
-        </Col>
-        <Col xs={24} sm={12}>
-          {/* 其它流面抛光精度 */}
-          <Form.Item
-            label="其它流面抛光精度"
-            name="otherSurfacePrecision"
-            rules={[
-              {
-                required: true,
-                message: "请选择或输入抛光精度",
-              },
-              ...autoCompleteIntervalInputRules,
-            ]}
-          >
-            <AutoCompleteIntervalInput
-              options={precisionOptions.otherSurface}
-              disabled={precisionLevel !== "custom"}
-              level={precisionLevel}
-              addonAfter={"μm"}
-            />
-          </Form.Item>
-        </Col>
-        <Col xs={24} sm={12}>
-          {/* 外形抛光精度 */}
-          <Form.Item
-            label="外形抛光精度"
-            name="shapePrecision"
-            rules={[
-              {
-                required: true,
-                message: "请选择或输入抛光精度",
-              },
-              ...autoCompleteIntervalInputRules,
-            ]}
-          >
-            <AutoCompleteIntervalInput
-              options={precisionOptions.shape}
-              disabled={precisionLevel !== "custom"}
-              level={precisionLevel}
-              addonAfter={"μm"}
-            />
-          </Form.Item>
-        </Col>
+        <Form.Item noStyle dependencies={["precisionLevel"]}>
+          {({ getFieldValue }) => {
+            const precisionLevel = getFieldValue("precisionLevel");
+            return (
+              <Col xs={24} sm={12}>
+                {/* 模唇流面抛光精度 */}
+                <Form.Item
+                  label="模唇流面抛光精度"
+                  name="lipSurfacePrecision"
+                  rules={[
+                    { required: true, message: "请选择或输入抛光精度" },
+                    ...autoCompleteIntervalInputRules,
+                  ]}
+                >
+                  <AutoCompleteIntervalInput
+                    options={precisionOptions.lipSurface}
+                    disabled={precisionLevel !== "custom"}
+                    level={precisionLevel}
+                    addonAfter={"μm"}
+                  />
+                </Form.Item>
+              </Col>
+            );
+          }}
+        </Form.Item>
+        <Form.Item noStyle dependencies={["precisionLevel"]}>
+          {({ getFieldValue }) => {
+            const precisionLevel = getFieldValue("precisionLevel");
+            return (
+              <Col xs={24} sm={12}>
+                {/* 其它流面抛光精度 */}
+                <Form.Item
+                  label="其它流面抛光精度"
+                  name="otherSurfacePrecision"
+                  rules={[
+                    {
+                      required: true,
+                      message: "请选择或输入抛光精度",
+                    },
+                    ...autoCompleteIntervalInputRules,
+                  ]}
+                >
+                  <AutoCompleteIntervalInput
+                    options={precisionOptions.otherSurface}
+                    disabled={precisionLevel !== "custom"}
+                    level={precisionLevel}
+                    addonAfter={"μm"}
+                  />
+                </Form.Item>
+              </Col>
+            );
+          }}
+        </Form.Item>
+        <Form.Item noStyle dependencies={["precisionLevel"]}>
+          {({ getFieldValue }) => {
+            const precisionLevel = getFieldValue("precisionLevel");
+            return (
+              <Col xs={24} sm={12}>
+                {/* 外形抛光精度 */}
+                <Form.Item
+                  label="外形抛光精度"
+                  name="shapePrecision"
+                  rules={[
+                    {
+                      required: true,
+                      message: "请选择或输入抛光精度",
+                    },
+                    ...autoCompleteIntervalInputRules,
+                  ]}
+                >
+                  <AutoCompleteIntervalInput
+                    options={precisionOptions.shape}
+                    disabled={precisionLevel !== "custom"}
+                    level={precisionLevel}
+                    addonAfter={"μm"}
+                  />
+                </Form.Item>
+              </Col>
+            );
+          }}
+        </Form.Item>
         <Col xs={12} md={12}>
           {/* 是否电镀 */}
           <Form.Item


### PR DESCRIPTION
## Summary
- enforce that either product width or die width is provided
- leave precision level logic managed via form dependencies

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Missing dependencies and TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_684bf8e66b3c832796decda731994f8f