### PR TITLE
Add manual clause defaults

### DIFF
--- a/src/components/quote/ContractTab.tsx
+++ b/src/components/quote/ContractTab.tsx
@@ -1,19 +1,27 @@
 import React from "react";
-import { Form, Switch } from "antd";
+import { Form, Switch, Button } from "antd";
 import TermsTable from "./TermsTable";
 import { Clause } from "../../types/types";
 
 interface ContractTabProps {
   value: Clause[];
   onChange: (terms: Clause[]) => void;
+  onSetDefault: () => void;
 }
 
-const ContractTab: React.FC<ContractTabProps> = ({ value, onChange }) => {
+const ContractTab: React.FC<ContractTabProps> = ({
+  value,
+  onChange,
+  onSetDefault,
+}) => {
   return (
     <>
       <Form.Item name="useCompanyContract" label="是否使用公司合同" valuePropName="checked">
         <Switch />
       </Form.Item>
+      <Button type="dashed" onClick={onSetDefault} style={{ marginBottom: 16 }}>
+        设置默认条款
+      </Button>
       <TermsTable value={value} onChange={onChange} />
     </>
   );

--- a/src/components/quote/QuoteTermsTab.tsx
+++ b/src/components/quote/QuoteTermsTab.tsx
@@ -1,14 +1,27 @@
 import React from "react";
+import { Button } from "antd";
 import TermsTable from "./TermsTable";
 import { Clause } from "../../types/types";
 
 interface QuoteTermsTabProps {
   value: Clause[];
   onChange: (terms: Clause[]) => void;
+  onSetDefault: () => void;
 }
 
-const QuoteTermsTab: React.FC<QuoteTermsTabProps> = ({ value, onChange }) => {
-  return <TermsTable value={value} onChange={onChange} />;
+const QuoteTermsTab: React.FC<QuoteTermsTabProps> = ({
+  value,
+  onChange,
+  onSetDefault,
+}) => {
+  return (
+    <>
+      <Button type="dashed" onClick={onSetDefault} style={{ marginBottom: 16 }}>
+        设置默认条款
+      </Button>
+      <TermsTable value={value} onChange={onChange} />
+    </>
+  );
 };
 
 export default QuoteTermsTab;


### PR DESCRIPTION
## Summary
- add default terms buttons to each clause tab
- integrate quote and contract terms with form data

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails to install dependencies)*
- `npm run lint` *(fails: cannot resolve @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_684c1cacb52c8327852df7051c6ef6e3