### PR TITLE
Fix default terms button

### DIFF
--- a/src/components/quote/QuoteForm.tsx
+++ b/src/components/quote/QuoteForm.tsx
@@ -326,22 +326,26 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
             label: "报价条约",
             key: "2",
             children: (
-              <QuoteTermsTab
-                value={quoteTerms}
-                onChange={handleQuoteTermsChange}
-                onSetDefault={setDefaultQuoteTerms}
-              />
+              <Form.Item name="quoteTerms" noStyle>
+                <QuoteTermsTab
+                  value={quoteTerms}
+                  onChange={handleQuoteTermsChange}
+                  onSetDefault={setDefaultQuoteTerms}
+                />
+              </Form.Item>
             ),
           },
           {
             label: "合同",
             key: "3",
             children: (
-              <ContractTab
-                value={contractTerms}
-                onChange={handleContractTermsChange}
-                onSetDefault={setDefaultContractTerms}
-              />
+              <Form.Item name="contractTerms" noStyle>
+                <ContractTab
+                  value={contractTerms}
+                  onChange={handleContractTermsChange}
+                  onSetDefault={setDefaultContractTerms}
+                />
+              </Form.Item>
             ),
           },
         ]}


### PR DESCRIPTION
## Summary
- wrap QuoteTermsTab and ContractTab with Form.Item

## Testing
- `npm run build` *(fails: Cannot find module '@wecom/jssdk')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c2f4e2fe883279b83c8864063e054