### PR TITLE
Disable template import for OtherForm

### DIFF
--- a/src/components/quote/ProductConfigForm/ImportProductModal.tsx
+++ b/src/components/quote/ProductConfigForm/ImportProductModal.tsx
@@ -20,12 +20,21 @@ const ImportProductModal: React.FC<ImportProductModalProps> = ({
   onImport,
   formType,
 }) => {
-  const [mode, setMode] = useState<"template" | "other">("template");
+  const isOtherForm = formType === "OtherForm";
+  const [mode, setMode] = useState<"template" | "other">(
+    isOtherForm ? "other" : "template"
+  );
   const [list, setList] = useState<ProductSearchResult[]>([]);
   const [selected, setSelected] = useState<ProductSearchResult>();
   const [selectedTemplate, setSelectedTemplate] = useState<QuoteTemplate>();
   const [loading, setLoading] = useState(false);
   const { templates, loading: tplLoading, refreshTemplates } = useTemplateStore();
+
+  useEffect(() => {
+    if (isOtherForm) {
+      setMode("other");
+    }
+  }, [isOtherForm]);
 
   useEffect(() => {
     if (open && mode === "template") {
@@ -83,12 +92,14 @@ const ImportProductModal: React.FC<ImportProductModalProps> = ({
           {
             key: "template",
             label: "从模版导入",
+            disabled: isOtherForm,
             children: (
               <div>
                 <div style={{ marginBottom: 16 }}>
                   <Button
                     type="primary"
                     onClick={() => window.open("/template/create", "_blank")}
+                    disabled={isOtherForm}
                   >
                     创建模版
                   </Button>

--- a/src/components/quote/ProductConfigForm/ProductConfigModal.tsx
+++ b/src/components/quote/ProductConfigForm/ProductConfigModal.tsx
@@ -144,7 +144,11 @@ const ProductConfigModal: React.FC<ProductConfigModalProps> = ({
         title={
           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
             <span>{quoteItem?.productCategory?.join("/")}</span>
-            <Button type="link" onClick={() => setImportOpen(true)}>
+            <Button
+              type="link"
+              onClick={() => setImportOpen(true)}
+              disabled={quoteItem?.formType === "OtherForm"}
+            >
               从模版导入
             </Button>
           </div>

--- a/src/components/template/TemplateFormModal.tsx
+++ b/src/components/template/TemplateFormModal.tsx
@@ -41,7 +41,11 @@ const TemplateFormModal: React.FC<TemplateFormModalProps> = ({ open, onClose }) 
       destroyOnClose
       forceRender
     >
-      <ProductConfigurationForm quoteId={0} quoteItem={template as any} />
+      <ProductConfigurationForm
+        quoteId={0}
+        quoteItem={template as any}
+        showPrice={false}
+      />
     </Modal>
   );
 };

--- a/src/page/template/TemplateFormPage.tsx
+++ b/src/page/template/TemplateFormPage.tsx
@@ -46,7 +46,11 @@ const TemplateFormPage: React.FC = () => {
 
   return (
     <div>
-      <ProductConfigurationForm quoteId={0} quoteItem={template as any} />
+      <ProductConfigurationForm
+        quoteId={0}
+        quoteItem={template as any}
+        showPrice={false}
+      />
       <div style={{ marginTop: 16 }}>
         <Button type="primary" onClick={handleSubmit} loading={saving}>
           保存


### PR DESCRIPTION
## Summary
- disable template import button if form type is `OtherForm`
- avoid template tab and creation when form type is `OtherForm`
- hide price form when creating templates

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c4f08d31c8327bcf90875dffacdd2