### PR TITLE
Fix template creation to respect form type

### DIFF
--- a/src/components/quote/ProductConfigForm/ImportProductModal.tsx
+++ b/src/components/quote/ProductConfigForm/ImportProductModal.tsx
@@ -98,7 +98,12 @@ const ImportProductModal: React.FC<ImportProductModalProps> = ({
                 <div style={{ marginBottom: 16 }}>
                   <Button
                     type="primary"
-                    onClick={() => window.open("/template/create", "_blank")}
+                    onClick={() =>
+                      window.open(
+                        `/template/create?formType=${formType ?? ""}`,
+                        "_blank"
+                      )
+                    }
                     disabled={isOtherForm}
                   >
                     创建模版

--- a/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
+++ b/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
@@ -21,6 +21,7 @@ interface ProductConfigurationFormProps {
   style?: any;
   showPrice?: boolean;
   readOnly?: boolean;
+  formType?: string;
 }
 const ProductConfigurationForm = forwardRef(
   (
@@ -32,6 +33,7 @@ const ProductConfigurationForm = forwardRef(
       style,
       showPrice = true,
       readOnly = false,
+      formType: formTypeProp,
     }: ProductConfigurationFormProps,
     ref
   ) => {
@@ -94,7 +96,8 @@ const ProductConfigurationForm = forwardRef(
       quoteItem?.productCategory,
       quoteId,
       quoteItem?.id ?? 0,
-      modelFormRef
+      modelFormRef,
+      formTypeProp
     );
 
 

--- a/src/components/quote/ProductConfigForm/formSelector.tsx
+++ b/src/components/quote/ProductConfigForm/formSelector.tsx
@@ -27,9 +27,10 @@ export function getFormByCategory(
   category: string[] | undefined,
   quoteId: number,
   quoteItemId: number,
-  modelFormRef: ModelFormRef
+  modelFormRef: ModelFormRef,
+  formTypeOverride?: string
 ): { form: React.ReactNode; formType: string } {
-  const formType = getFormType(category);
+  const formType = formTypeOverride || getFormType(category);
   if (formType === "DieForm")
     return {
       form: <DieForm quoteItemId={quoteItemId} quoteId={quoteId} ref={modelFormRef} />,

--- a/src/page/template/TemplateFormPage.tsx
+++ b/src/page/template/TemplateFormPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Button, App } from "antd";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import ProductConfigurationForm from "../../components/quote/ProductConfigForm/ProductConfigurationForm";
 import { QuoteTemplate } from "../../types/types";
 import { useTemplateStore } from "../../store/useTemplateStore";
@@ -8,11 +8,13 @@ import { TemplateService } from "../../api/services/template.service";
 
 const TemplateFormPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const [template, setTemplate] = useState<QuoteTemplate | null>(null);
   const { refreshTemplates } = useTemplateStore();
   const { message } = App.useApp();
   const [saving, setSaving] = useState(false);
+  const formTypeParam = searchParams.get("formType") || undefined;
 
   useEffect(() => {
     if (!id) {
@@ -50,6 +52,7 @@ const TemplateFormPage: React.FC = () => {
         quoteId={0}
         quoteItem={template as any}
         showPrice={false}
+        formType={formTypeParam || template?.templateType}
       />
       <div style={{ marginTop: 16 }}>
         <Button type="primary" onClick={handleSubmit} loading={saving}>


### PR DESCRIPTION
## Summary
- allow `ProductConfigurationForm` to accept a `formType` override
- add optional override parameter for `getFormByCategory`
- pass `formType` from the import modal when opening the template page
- show the correct configuration form on the template page based on query param

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c5356a85883279b6a4967570a903a