### PR TITLE
Add template creation workflow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ import HistoryQuoteTablePage from "./page/quote/HistoryQuoteTablePage";
 import OAQuoteTablePage from "./page/quote/OAQuoteTablePage";
 import QuoteFormPage from "./page/quote/QuoteFormPage";
 import TemplateListPage from "./page/template/TemplateListPage";
-import TemplateFormPage from "./page/template/TemplateFormPage";
+import TemplateCreatePage from "./page/template/TemplateCreatePage";
 import { NoPermissionPage } from "./page/NoPermissionPage";
 
 const App: React.FC = () => {
@@ -45,8 +45,8 @@ const App: React.FC = () => {
               </Route>
               <Route path="template" element={<Outlet />}>
                 <Route index element={<TemplateListPage />} />
-                <Route path="create" element={<TemplateFormPage />} />
-                <Route path=":id" element={<TemplateFormPage />} />
+                <Route path="create" element={<TemplateCreatePage />} />
+                <Route path=":id" element={<TemplateCreatePage />} />
               </Route>
             </Route>
             <Route path="/jdy_redirect" element={<JdyRedirect />} />

--- a/src/components/template/TemplateCreate.tsx
+++ b/src/components/template/TemplateCreate.tsx
@@ -1,0 +1,129 @@
+import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
+import { Form, Input, Tabs, Select } from "antd";
+import MaterialSelect from "../general/MaterialSelect";
+import { CustomSelect } from "../general/CustomSelect";
+import ProductConfigurationForm from "../quote/ProductConfigForm/ProductConfigurationForm";
+import { QuoteTemplate } from "../../types/types";
+
+export interface TemplateCreateRef {
+  getData: () => Promise<Partial<QuoteTemplate>>;
+}
+
+interface TemplateCreateProps {
+  initialValues?: Partial<QuoteTemplate>;
+  formType?: string;
+}
+
+const INDUSTRY = {
+  新能源及储能: ["动力电池（锂电、氢燃料、钠电）", "光伏新能源"],
+  半导体及电子元器件: ["半导体（泛半导体）", "先进封装", "高端显示"],
+  消费电子: ["消费电子"],
+  医疗及环保: ["医疗卫生", "环保行业"],
+  工业制造及材料: ["新型建材", "包装行业"],
+};
+
+const FORM_TYPE_OPTIONS = [
+  { label: "平模", value: "DieForm" },
+  { label: "智能调节器", value: "SmartRegulator" },
+  { label: "熔体计量泵", value: "MeteringPumpForm" },
+  { label: "共挤复合分配器", value: "FeedblockForm" },
+  { label: "过滤器", value: "FilterForm" },
+  { label: "测厚仪", value: "ThicknessGaugeForm" },
+  { label: "液压站", value: "HydraulicStationForm" },
+  { label: "赠品", value: "GiftForm" },
+  { label: "其他", value: "OtherForm" },
+];
+
+const TemplateCreate = forwardRef<TemplateCreateRef, TemplateCreateProps>(
+  ({ initialValues, formType: fixedFormType }, ref) => {
+    const [infoForm] = Form.useForm();
+    const configRef = useRef<any>(null);
+    const [formType, setFormType] = useState(
+      fixedFormType || initialValues?.templateType || FORM_TYPE_OPTIONS[0].value
+    );
+
+    useEffect(() => {
+      if (initialValues) {
+        infoForm.setFieldsValue({
+          name: initialValues.name,
+          materials: initialValues.materials,
+          industries: initialValues.industries,
+          templateType: fixedFormType || initialValues.templateType,
+        });
+        if (initialValues.templateType) {
+          setFormType(fixedFormType || initialValues.templateType);
+        }
+      }
+    }, [initialValues, fixedFormType]);
+
+    useImperativeHandle(ref, () => ({
+      async getData() {
+        const base = await infoForm.validateFields();
+        const config = configRef.current?.modelForm?.getFieldsValue?.() || {};
+        return {
+          ...initialValues,
+          ...base,
+          templateType: formType,
+          config,
+        } as Partial<QuoteTemplate>;
+      },
+    }));
+
+    return (
+      <Tabs
+        defaultActiveKey="info"
+        items={[
+          {
+            key: "info",
+            label: "基本信息",
+            forceRender: true,
+            children: (
+              <Form form={infoForm} layout="vertical">
+                <Form.Item
+                  label="名称"
+                  name="name"
+                  rules={[{ required: true, message: "请输入名称" }]}
+                >
+                  <Input />
+                </Form.Item>
+                <Form.Item label="适用材料" name="materials">
+                  <MaterialSelect />
+                </Form.Item>
+                <Form.Item label="行业" name="industries">
+                  <CustomSelect mode="tags" initialGroups={INDUSTRY} />
+                </Form.Item>
+                <Form.Item
+                  label="类型"
+                  name="templateType"
+                  rules={[{ required: true, message: "请选择类型" }]}
+                >
+                  <Select
+                    options={FORM_TYPE_OPTIONS}
+                    disabled={!!fixedFormType}
+                    onChange={(val) => setFormType(val)}
+                  />
+                </Form.Item>
+              </Form>
+            ),
+          },
+          {
+            key: "config",
+            label: "配置",
+            forceRender: true,
+            children: (
+              <ProductConfigurationForm
+                quoteId={0}
+                quoteItem={initialValues as any}
+                showPrice={false}
+                formType={formType}
+                ref={configRef}
+              />
+            ),
+          },
+        ]}
+      />
+    );
+  }
+);
+
+export default TemplateCreate;

--- a/src/components/template/TemplateCreateModal.tsx
+++ b/src/components/template/TemplateCreateModal.tsx
@@ -1,0 +1,51 @@
+import React, { useRef, useState } from "react";
+import { Modal, Button } from "antd";
+import TemplateCreate, { TemplateCreateRef } from "./TemplateCreate";
+import { TemplateService } from "../../api/services/template.service";
+import { useTemplateStore } from "../../store/useTemplateStore";
+
+interface TemplateCreateModalProps {
+  open: boolean;
+  onClose: () => void;
+  formType?: string;
+}
+
+const TemplateCreateModal: React.FC<TemplateCreateModalProps> = ({ open, onClose, formType }) => {
+  const ref = useRef<TemplateCreateRef>(null);
+  const refresh = useTemplateStore((s) => s.refreshTemplates);
+  const [saving, setSaving] = useState(false);
+
+  const handleOk = async () => {
+    if (!ref.current) return;
+    const data = await ref.current.getData();
+    setSaving(true);
+    try {
+      await TemplateService.createTemplate(data);
+      await refresh();
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      title="创建模版"
+      onCancel={onClose}
+      width={800}
+      destroyOnClose
+      forceRender
+      footer={[
+        <Button key="cancel" onClick={onClose}>取消</Button>,
+        <Button key="ok" type="primary" onClick={handleOk} loading={saving}>
+          保存
+        </Button>,
+      ]}
+    >
+      <TemplateCreate ref={ref} formType={formType} />
+    </Modal>
+  );
+};
+
+export default TemplateCreateModal;

--- a/src/page/template/TemplateCreatePage.tsx
+++ b/src/page/template/TemplateCreatePage.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Button, App } from "antd";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import TemplateCreate, { TemplateCreateRef } from "../../components/template/TemplateCreate";
+import { TemplateService } from "../../api/services/template.service";
+import { useTemplateStore } from "../../store/useTemplateStore";
+import { QuoteTemplate } from "../../types/types";
+
+const TemplateCreatePage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
+  const fixedType = searchParams.get("formType") || undefined;
+  const { message } = App.useApp();
+  const navigate = useNavigate();
+  const { refreshTemplates } = useTemplateStore();
+  const ref = useRef<TemplateCreateRef>(null);
+  const [initial, setInitial] = useState<QuoteTemplate | undefined>();
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (id) {
+      TemplateService.getTemplate(id).then(setInitial);
+    } else {
+      setInitial(undefined);
+    }
+  }, [id]);
+
+  const handleSave = async () => {
+    if (!ref.current) return;
+    const data = await ref.current.getData();
+    setSaving(true);
+    try {
+      if (id) {
+        await TemplateService.updateTemplate(id, data);
+      } else {
+        await TemplateService.createTemplate(data);
+      }
+      await refreshTemplates();
+      message.success("保存成功");
+      navigate("/template");
+    } catch (e) {
+      console.error(e);
+      message.error("保存失败");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div>
+      <TemplateCreate ref={ref} initialValues={initial} formType={fixedType} />
+      <div style={{ marginTop: 16 }}>
+        <Button type="primary" onClick={handleSave} loading={saving}>
+          保存
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default TemplateCreatePage;

--- a/src/page/template/TemplateListPage.tsx
+++ b/src/page/template/TemplateListPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Button } from "antd";
 import { useTemplateStore } from "../../store/useTemplateStore";
 import TemplateTable from "../../components/template/TemplateTable";
-import TemplateFormModal from "../../components/template/TemplateFormModal";
+import TemplateCreateModal from "../../components/template/TemplateCreateModal";
 import { useNavigate } from "react-router-dom";
 
 const TemplateListPage: React.FC = () => {
@@ -30,7 +30,7 @@ const TemplateListPage: React.FC = () => {
         loading={loading}
         onDoubleClick={(tpl) => navigate(`/template/${tpl.id}`)}
       />
-      <TemplateFormModal open={open} onClose={() => setOpen(false)} />
+      <TemplateCreateModal open={open} onClose={() => setOpen(false)} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add TemplateCreate component with info/config tabs
- show TemplateCreate modal and page
- wire up modal in template list page
- update routes to use new template page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c5ee3d32c83279bb2524228bfb7d4