### PR TITLE
Fix modal reset and import form

### DIFF
--- a/src/components/quote/ProductConfigForm/ImportProductModal.tsx
+++ b/src/components/quote/ProductConfigForm/ImportProductModal.tsx
@@ -125,6 +125,7 @@ const ImportProductModal: React.FC<ImportProductModalProps> = ({
                     <ProductConfigurationForm
                       quoteId={0}
                       quoteItem={selectedTemplate as any}
+                      formType={selectedTemplate.templateType}
                       showPrice={false}
                       readOnly
                     />
@@ -171,6 +172,7 @@ const ImportProductModal: React.FC<ImportProductModalProps> = ({
                     <ProductConfigurationForm
                       quoteId={0}
                       quoteItem={selected.item}
+                      formType={selected.item.formType || formType}
                       showPrice={false}
                       readOnly
                     />

--- a/src/components/template/TemplateCreate.tsx
+++ b/src/components/template/TemplateCreate.tsx
@@ -16,6 +16,7 @@ import TextArea from "antd/es/input/TextArea";
 
 export interface TemplateCreateRef {
   getData: () => Promise<Partial<QuoteTemplate>>;
+  reset: () => void;
 }
 
 interface TemplateCreateProps {
@@ -76,6 +77,11 @@ const TemplateCreate = forwardRef<TemplateCreateRef, TemplateCreateProps>(
           templateType: formType,
           config,
         } as Partial<QuoteTemplate>;
+      },
+      reset() {
+        infoForm.resetFields();
+        configRef.current?.form?.resetFields?.();
+        setFormType(fixedFormType || FORM_TYPE_OPTIONS[0].value);
       },
     }));
 

--- a/src/components/template/TemplateCreateModal.tsx
+++ b/src/components/template/TemplateCreateModal.tsx
@@ -38,6 +38,7 @@ const TemplateCreateModal: React.FC<TemplateCreateModalProps> = ({
       title="创建模版"
       onCancel={onClose}
       width={700}
+      afterClose={() => ref.current?.reset()}
       destroyOnHidden
       forceRender
       footer={[

--- a/src/store/useQuoteStore.ts
+++ b/src/store/useQuoteStore.ts
@@ -363,6 +363,7 @@ export const useQuoteStore = create<QuotesStore>()(
     },
     // Helper function to find item by ID (searches recursively in children)
     findItemById: (items, itemId) => {
+      if (!Array.isArray(items)) return undefined;
       for (const item of items) {
         if (item.id === itemId) return item;
         // if (item.children) {


### PR DESCRIPTION
## Summary
- expose `reset` API in TemplateCreate
- reset TemplateCreate modal when closed
- pass form type to ProductConfigurationForm in ImportProductModal
- guard against missing arrays in store

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_684c797cd40083279bd97b15646838ea