### PR TITLE
Add readOnly mode to PartsForm

### DIFF
--- a/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
+++ b/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
@@ -101,7 +101,8 @@ const ProductConfigurationForm = forwardRef(
       quoteId,
       quoteItem?.id ?? 0,
       modelFormRef,
-      formTypeProp
+      formTypeProp,
+      readOnly
     );
 
     useEffect(() => {

--- a/src/components/quote/ProductConfigForm/formSelector.tsx
+++ b/src/components/quote/ProductConfigForm/formSelector.tsx
@@ -28,7 +28,8 @@ export function getFormByCategory(
   quoteId: number,
   quoteItemId: number,
   modelFormRef: ModelFormRef,
-  formTypeOverride?: string
+  formTypeOverride?: string,
+  readOnly?: boolean
 ): { form: React.ReactNode; formType: string } {
   const formType = formTypeOverride || getFormType(category);
   if (formType === "DieForm")
@@ -109,6 +110,6 @@ export function getFormByCategory(
       formType,
     };
   if (formType === "PartsForm")
-    return { form: <PartsForm ref={modelFormRef} />, formType };
+    return { form: <PartsForm ref={modelFormRef} readOnly={readOnly} />, formType };
   return { form: <OtherForm ref={modelFormRef} />, formType };
 }

--- a/src/components/quoteForm/PartsForm.tsx
+++ b/src/components/quoteForm/PartsForm.tsx
@@ -16,7 +16,11 @@ interface PartFormRef {
   form: FormInstance;
 }
 
-const PartForm = forwardRef<PartFormRef>((props, ref) => {
+interface PartFormProps {
+  readOnly?: boolean;
+}
+
+const PartForm = forwardRef<PartFormRef, PartFormProps>(({ readOnly = false }, ref) => {
   const [form] = Form.useForm();
 
   useImperativeHandle(ref, () => ({
@@ -28,7 +32,11 @@ const PartForm = forwardRef<PartFormRef>((props, ref) => {
       <ProFormList
         name="parts"
         label="配件明细"
-        creatorButtonProps={{ creatorButtonText: "新增赠品" }}
+        creatorButtonProps={
+          readOnly ? false : { creatorButtonText: "新增赠品" }
+        }
+        deleteIconProps={readOnly ? false : undefined}
+        copyIconProps={readOnly ? false : undefined}
         alwaysShowItemLabel
         rules={[
           {
@@ -57,6 +65,7 @@ const PartForm = forwardRef<PartFormRef>((props, ref) => {
                   options={[]}
                   style={{ width: "100%" }}
                   placeholder="赠品名称"
+                  disabled={readOnly}
                 />
               </ProForm.Item>
             </Col>
@@ -71,6 +80,7 @@ const PartForm = forwardRef<PartFormRef>((props, ref) => {
                   min={1}
                   style={{ width: "100%" }}
                   controls={false}
+                  disabled={readOnly}
                 />
               </ProForm.Item>
             </Col>
@@ -81,7 +91,7 @@ const PartForm = forwardRef<PartFormRef>((props, ref) => {
                 rules={[{ required: true, message: "请选择单位" }]}
                 initialValue="件"
               >
-                <Select style={{ width: "100%" }}>
+                <Select style={{ width: "100%" }} disabled={readOnly}>
                   <Select.Option value="件">件</Select.Option>
                   <Select.Option value="套">套</Select.Option>
                   <Select.Option value="个">个</Select.Option>
@@ -99,6 +109,7 @@ const PartForm = forwardRef<PartFormRef>((props, ref) => {
                   precision={2}
                   controls={false}
                   style={{ width: "100%" }}
+                  disabled={readOnly}
                 />
               </ProForm.Item>
             </Col>

--- a/src/components/template/TemplateCreate.tsx
+++ b/src/components/template/TemplateCreate.tsx
@@ -137,8 +137,8 @@ const TemplateCreate = forwardRef<TemplateCreateRef, TemplateCreateProps>(
             key: "config",
             label: "配置",
             forceRender: true,
-            children: getFormByCategory(undefined, 0, 0, configRef, formType)
-              .form,
+            children:
+              getFormByCategory(undefined, 0, 0, configRef, formType, false).form,
           },
         ]}
       />


### PR DESCRIPTION
## Summary
- support `readOnly` prop in `PartsForm` to hide list controls
- plumb `readOnly` through `formSelector` and `ProductConfigurationForm`
- update template creation form usage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_684c829d76d48327ad11a2698176e941