### PR TITLE
Enable read-only prop across quote forms

### DIFF
--- a/src/components/general/InputWithButton.tsx
+++ b/src/components/general/InputWithButton.tsx
@@ -14,6 +14,8 @@ export interface InputWithButtonProps
   buttonProps?: ButtonProps;
   /** Click handler for the button */
   onButtonClick?: () => void;
+  /** Disable both input and button */
+  disabled?: boolean;
 }
 
 const InputWithButton: React.FC<InputWithButtonProps> = ({
@@ -22,6 +24,7 @@ const InputWithButton: React.FC<InputWithButtonProps> = ({
   buttonText = "Submit",
   buttonProps,
   onButtonClick,
+  disabled = false,
   ...inputProps
 }) => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -30,8 +33,18 @@ const InputWithButton: React.FC<InputWithButtonProps> = ({
 
   return (
     <Space.Compact style={{ width: "100%" }}>
-      <Input value={value} onChange={handleChange} {...inputProps} />
-      <Button type="primary" onClick={onButtonClick} {...buttonProps}>
+      <Input
+        value={value}
+        onChange={handleChange}
+        disabled={disabled}
+        {...inputProps}
+      />
+      <Button
+        type="primary"
+        onClick={onButtonClick}
+        disabled={disabled}
+        {...buttonProps}
+      >
         {buttonText}
       </Button>
     </Space.Compact>

--- a/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
+++ b/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
@@ -157,7 +157,11 @@ const ProductConfigurationForm = forwardRef(
                 label: "价格配置",
                 key: "2",
                 children: (
-                  <PriceForm ref={priceFormRef} onGenerateName={generateName} />
+                  <PriceForm
+                    ref={priceFormRef}
+                    onGenerateName={generateName}
+                    readOnly={readOnly}
+                  />
                 ),
                 forceRender: true,
               });
@@ -165,18 +169,6 @@ const ProductConfigurationForm = forwardRef(
             return arr;
           })()}
         />
-        {readOnly && (
-          <div
-            style={{
-              position: "absolute",
-              top: 0,
-              left: 0,
-              right: 0,
-              bottom: 0,
-              zIndex: 10,
-            }}
-          />
-        )}
       </div>
     );
   }

--- a/src/components/quote/ProductConfigForm/formSelector.tsx
+++ b/src/components/quote/ProductConfigForm/formSelector.tsx
@@ -39,6 +39,7 @@ export function getFormByCategory(
           quoteItemId={quoteItemId}
           quoteId={quoteId}
           ref={modelFormRef}
+          readOnly={readOnly}
         />
       ),
       formType,
@@ -50,6 +51,7 @@ export function getFormByCategory(
           ref={modelFormRef}
           quoteId={quoteId}
           quoteItemId={quoteItemId}
+          readOnly={readOnly}
         />
       ),
       formType,
@@ -61,6 +63,7 @@ export function getFormByCategory(
           ref={modelFormRef}
           quoteId={quoteId}
           quoteItemId={quoteItemId}
+          readOnly={readOnly}
         />
       ),
       formType,
@@ -72,6 +75,7 @@ export function getFormByCategory(
           ref={modelFormRef}
           quoteId={quoteId}
           quoteItemId={quoteItemId}
+          readOnly={readOnly}
         />
       ),
       formType,
@@ -83,6 +87,7 @@ export function getFormByCategory(
           ref={modelFormRef}
           quoteId={quoteId}
           quoteItemId={quoteItemId}
+          readOnly={readOnly}
         />
       ),
       formType,
@@ -94,6 +99,7 @@ export function getFormByCategory(
           ref={modelFormRef}
           quoteId={quoteId}
           quoteItemId={quoteItemId}
+          readOnly={readOnly}
         />
       ),
       formType,
@@ -105,11 +111,12 @@ export function getFormByCategory(
           ref={modelFormRef}
           quoteId={quoteId}
           quoteItemId={quoteItemId}
+          readOnly={readOnly}
         />
       ),
       formType,
     };
   if (formType === "PartsForm")
     return { form: <PartsForm ref={modelFormRef} readOnly={readOnly} />, formType };
-  return { form: <OtherForm ref={modelFormRef} />, formType };
+  return { form: <OtherForm ref={modelFormRef} readOnly={readOnly} />, formType };
 }

--- a/src/components/quoteForm/FeedblockForm/FeedblockForm.tsx
+++ b/src/components/quoteForm/FeedblockForm/FeedblockForm.tsx
@@ -40,7 +40,14 @@ const MATERIAL_OPTIONS = {
 };
 
 const FeedblockForm = forwardRef(
-  ({ quoteId, quoteItemId }: { quoteId: number; quoteItemId: number }, ref) => {
+  (
+    {
+      quoteId,
+      quoteItemId,
+      readOnly = false,
+    }: { quoteId: number; quoteItemId: number; readOnly?: boolean },
+    ref
+  ) => {
     const [form] = Form.useForm();
 
     useImperativeHandle(ref, () => ({
@@ -107,6 +114,7 @@ const FeedblockForm = forwardRef(
           form={form}
           submitter={false}
           onValuesChange={handleFieldsChange}
+          disabled={readOnly}
         >
           <Row gutter={16}>
             <Col xs={12} md={6}>

--- a/src/components/quoteForm/FilterForm/FilterForm.tsx
+++ b/src/components/quoteForm/FilterForm/FilterForm.tsx
@@ -16,7 +16,14 @@ import MeshBeltControlCard from "./MeshBeltControlCard";
 import { ProCard } from "@ant-design/pro-components";
 
 const FilterForm = forwardRef(
-  ({ quoteId, quoteItemId }: { quoteId: number; quoteItemId: number }, ref) => {
+  (
+    {
+      quoteId,
+      quoteItemId,
+      readOnly = false,
+    }: { quoteId: number; quoteItemId: number; readOnly?: boolean },
+    ref
+  ) => {
     const [form] = Form.useForm();
     const filters = useProductStore((state) => state.filter);
     const fetchFilter = useProductStore((state) => state.fetchFilter);
@@ -116,6 +123,7 @@ const FilterForm = forwardRef(
         form={form}
         submitter={false}
         onValuesChange={handleFieldsChange}
+        disabled={readOnly}
       >
         <FilterSelection form={form} filters={filters} />
         <ProCard

--- a/src/components/quoteForm/HydraulicStationForm/HydraulicStationForm.tsx
+++ b/src/components/quoteForm/HydraulicStationForm/HydraulicStationForm.tsx
@@ -15,10 +15,18 @@ import { useQuoteStore } from "../../../store/useQuoteStore";
 interface HydraulicStationFormProps {
   quoteId: number;
   quoteItemId: number;
+  readOnly?: boolean;
 }
 
 const HydraulicStationForm = forwardRef(
-  ({ quoteId, quoteItemId }: HydraulicStationFormProps, ref) => {
+  (
+    {
+      quoteId,
+      quoteItemId,
+      readOnly = false,
+    }: HydraulicStationFormProps & { readOnly?: boolean },
+    ref
+  ) => {
     const [form] = Form.useForm();
 
     useImperativeHandle(ref, () => ({
@@ -35,7 +43,7 @@ const HydraulicStationForm = forwardRef(
       : undefined;
 
     return (
-      <ProForm layout="vertical" form={form} submitter={false}>
+      <ProForm layout="vertical" form={form} submitter={false} disabled={readOnly}>
         {linkedName && (
           <Typography.Text
             type="secondary"

--- a/src/components/quoteForm/MeteringPumpForm/MeteringPumpForm.tsx
+++ b/src/components/quoteForm/MeteringPumpForm/MeteringPumpForm.tsx
@@ -19,7 +19,14 @@ interface PriceFormRef {
 }
 
 const MeteringPumpForm = forwardRef(
-  ({ quoteId, quoteItemId }: { quoteId: number; quoteItemId: number }, ref) => {
+  (
+    {
+      quoteId,
+      quoteItemId,
+      readOnly = false,
+    }: { quoteId: number; quoteItemId: number; readOnly?: boolean },
+    ref
+  ) => {
     const [form] = Form.useForm();
     const optionsRef = useRef<string[]>([]);
     const quoteItems = useQuoteStore
@@ -186,6 +193,7 @@ const MeteringPumpForm = forwardRef(
           form={form}
           submitter={false}
           onValuesChange={handleFieldsChange}
+          disabled={readOnly}
         >
           <ModelSelection />
           <ModelOption />

--- a/src/components/quoteForm/OtherForm.tsx
+++ b/src/components/quoteForm/OtherForm.tsx
@@ -5,7 +5,10 @@ interface OtherFormRef {
   form: FormInstance; // 明确定义暴露的form实例
 }
 
-export const OtherForm = forwardRef<OtherFormRef>((props, ref) => {
+export const OtherForm = forwardRef<
+  OtherFormRef,
+  { readOnly?: boolean }
+>(({ readOnly = false }, ref) => {
   const [form] = Form.useForm();
 
   // 暴露form实例给父组件
@@ -15,7 +18,7 @@ export const OtherForm = forwardRef<OtherFormRef>((props, ref) => {
   // 计算小计``
 
   return (
-    <Form layout={"vertical"} form={form}>
+    <Form layout={"vertical"} form={form} disabled={readOnly}>
       <Form.Item
         name="remark"
         label="规格型号"

--- a/src/components/quoteForm/PriceForm.tsx
+++ b/src/components/quoteForm/PriceForm.tsx
@@ -17,6 +17,7 @@ interface PriceFormRef {
 
 interface PriceFormProps {
   onGenerateName?: () => string | undefined;
+  readOnly?: boolean;
 }
 
 const brandOption = [
@@ -26,7 +27,7 @@ const brandOption = [
 ];
 
 const PriceForm = forwardRef<PriceFormRef, PriceFormProps>(
-  ({ onGenerateName }, ref) => {
+  ({ onGenerateName, readOnly = false }, ref) => {
     const [form] = Form.useForm();
     // 暴露form实例给父组件
     useImperativeHandle(ref, () => ({
@@ -59,6 +60,7 @@ const PriceForm = forwardRef<PriceFormRef, PriceFormProps>(
         // preserve={false}
         form={form}
         onValuesChange={handleValuesChange}
+        disabled={readOnly}
       >
         <Row gutter={20}>
           <Col xs={12} sm={12}>
@@ -71,6 +73,8 @@ const PriceForm = forwardRef<PriceFormRef, PriceFormProps>(
                 style={{ width: "100%" }}
                 buttonText="自动生成名称"
                 onButtonClick={handleGenerateName}
+                disabled={readOnly}
+                buttonProps={{ disabled: readOnly }}
               />
             </Form.Item>
           </Col>

--- a/src/components/quoteForm/SmartRegulator.tsx
+++ b/src/components/quoteForm/SmartRegulator.tsx
@@ -30,8 +30,8 @@ const vison = [
 
 const SmartRegulator = forwardRef<
   PriceFormRef,
-  { quoteId: number; quoteItemId: number }
->(({ quoteId, quoteItemId }, ref) => {
+  { quoteId: number; quoteItemId: number; readOnly?: boolean }
+>(({ quoteId, quoteItemId, readOnly = false }, ref) => {
   const [form] = Form.useForm();
   const [isBundled] = useState<boolean>(true);
   const quoteItems = useQuoteStore
@@ -90,6 +90,7 @@ const SmartRegulator = forwardRef<
         form={form}
         submitter={false}
         onValuesChange={handleValuesChange}
+        disabled={readOnly}
       >
         <Row gutter={16}>
           <Col xs={12} md={8}>

--- a/src/components/quoteForm/ThicknessGaugeForm/ThicknessGaugeForm.tsx
+++ b/src/components/quoteForm/ThicknessGaugeForm/ThicknessGaugeForm.tsx
@@ -8,8 +8,8 @@ const widths = [500, 1000, 1500, 2000, 2500, 3000, 3500];
 
 const ThicknessGaugeForm = forwardRef<
   any,
-  { quoteId: number; quoteItemId: number }
->((props, ref) => {
+  { quoteId: number; quoteItemId: number; readOnly?: boolean }
+>(({ readOnly = false }, ref) => {
   const [form] = Form.useForm();
 
   useImperativeHandle(ref, () => ({
@@ -43,6 +43,7 @@ const ThicknessGaugeForm = forwardRef<
       form={form}
       submitter={false}
       onValuesChange={handleValuesChange}
+      disabled={readOnly}
     >
       <Row gutter={16}>
         <Col xs={12} md={6}>

--- a/src/components/quoteForm/dieForm/DieForm.tsx
+++ b/src/components/quoteForm/dieForm/DieForm.tsx
@@ -16,7 +16,14 @@ interface PriceFormRef {
 }
 
 const DieForm = forwardRef(
-  ({ quoteId, quoteItemId }: { quoteId: number; quoteItemId: number }, ref) => {
+  (
+    {
+      quoteId,
+      quoteItemId,
+      readOnly = false,
+    }: { quoteId: number; quoteItemId: number; readOnly?: boolean },
+    ref
+  ) => {
     const [form] = Form.useForm();
     const quoteItems = useQuoteStore
       .getState()
@@ -171,6 +178,7 @@ const DieForm = forwardRef(
           form={form}
           submitter={false}
           onValuesChange={handleFieldsChange}
+          disabled={readOnly}
         >
           <SameProduct />
           <Form.Item noStyle dependencies={["hasCart"]}>

--- a/src/components/template/TemplateFormModal.tsx
+++ b/src/components/template/TemplateFormModal.tsx
@@ -8,9 +8,14 @@ import { TemplateService } from "../../api/services/template.service";
 interface TemplateFormModalProps {
   open: boolean;
   onClose: () => void;
+  readOnly?: boolean;
 }
 
-const TemplateFormModal: React.FC<TemplateFormModalProps> = ({ open, onClose }) => {
+const TemplateFormModal: React.FC<TemplateFormModalProps> = ({
+  open,
+  onClose,
+  readOnly = false,
+}) => {
   const [template, setTemplate] = useState<QuoteTemplate | null>(null);
   const [saving, setSaving] = useState(false);
   const refresh = useTemplateStore((s) => s.refreshTemplates);
@@ -45,6 +50,7 @@ const TemplateFormModal: React.FC<TemplateFormModalProps> = ({ open, onClose }) 
         quoteId={0}
         quoteItem={template as any}
         showPrice={false}
+        readOnly={readOnly}
       />
     </Modal>
   );


### PR DESCRIPTION
## Summary
- expose `disabled` handling in `InputWithButton`
- forward `readOnly` to all form components via `formSelector`
- propagate `readOnly` in `ProductConfigurationForm` and remove overlay
- support read-only mode in price and product forms
- allow templates to display configuration forms in read-only mode

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies and TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_684d2d21fcfc8327a55b4ba49e9a94bd