### PR TITLE
Configure path aliases and update imports

### DIFF
--- a/src/api/http/interceptors.ts
+++ b/src/api/http/interceptors.ts
@@ -1,11 +1,11 @@
 import { AxiosInstance } from "axios";
-// import { useAuthStore } from "../../store/auth";
+// import { useAuthStore } from "@/store/auth";
 // import { useAuthStore } from '@/stores/auth'; // 或从context获取
 
 export const setupInterceptors = (instance: AxiosInstance) => {
   // 请求拦截
   instance.interceptors.request.use(async (config) => {
-    const { useAuthStore } = await import("../../store/useAuthStore");
+    const { useAuthStore } = await import("@/store/useAuthStore");
     const token = useAuthStore.getState().token;
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;

--- a/src/api/services/auth.service.ts
+++ b/src/api/services/auth.service.ts
@@ -1,5 +1,5 @@
 // import type { LoginParams, UserInfo } from '../types/auth.d';
-import { Position } from "../../types/types";
+import { Position } from "@/types/types";
 import { apiClient } from "../http/client";
 
 export const AuthService = {

--- a/src/api/services/product.service.ts
+++ b/src/api/services/product.service.ts
@@ -1,5 +1,5 @@
 import { apiClient } from "../http/client";
-import { ProductSearchResult } from "../../types/types";
+import { ProductSearchResult } from "@/types/types";
 
 export const ProductService = {
   async searchProducts(

--- a/src/api/services/quote.service.ts
+++ b/src/api/services/quote.service.ts
@@ -1,7 +1,7 @@
 // import type { LoginParams, UserInfo } from '../types/auth.d';
 import { redirect } from "react-router-dom";
 import { apiClient } from "../http/client";
-import { Quote, QuoteItem } from "../../types/types";
+import { Quote, QuoteItem } from "@/types/types";
 import axios from "axios";
 
 export const QuoteService = {

--- a/src/api/services/template.service.ts
+++ b/src/api/services/template.service.ts
@@ -1,5 +1,5 @@
 import { apiClient } from "../http/client";
-import { QuoteTemplate } from "../../types/types";
+import { QuoteTemplate } from "@/types/types";
 
 export const TemplateService = {
   async getTemplates(params?: { formType?: string }) {

--- a/src/components/general/AuthGuard.tsx
+++ b/src/components/general/AuthGuard.tsx
@@ -1,16 +1,16 @@
 import { JSX, ReactNode, useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { message, Spin } from "antd";
-import { useAuthStore } from "../../store/useAuthStore";
+import { useAuthStore } from "@/store/useAuthStore";
 import {
   generateQywxLoginUrl,
   getLocation,
   isInWeChatEnvironment,
   register,
   wwLoginUrl,
-} from "../../util/wecom";
-import { useGeolocation } from "../../hook/useGeolocation";
-import { AuthService } from "../../api/services/auth.service";
+} from "@/util/wecom";
+import { useGeolocation } from "@/hook/useGeolocation";
+import { AuthService } from "@/api/services/auth.service";
 import * as ww from "@wecom/jssdk";
 
 export const AuthGuard: React.FC<{ children: ReactNode }> = ({ children }) => {

--- a/src/components/general/AutoCompleteIntervalInput.tsx
+++ b/src/components/general/AutoCompleteIntervalInput.tsx
@@ -1,7 +1,7 @@
 import { DefaultOptionType } from "antd/es/select";
 import { IntervalInput } from "./IntervalInput";
 import { useEffect, useState } from "react";
-import type { IntervalValue } from "../../types/types";
+import type { IntervalValue } from "@/types/types";
 import { AutoComplete } from "antd";
 import { IntervalInput1 } from "./IntervalInput1";
 

--- a/src/components/general/CompanySearchSelect.tsx
+++ b/src/components/general/CompanySearchSelect.tsx
@@ -3,8 +3,8 @@ import { Select, Spin } from "antd";
 import type { SelectProps } from "antd";
 import { useDebounce } from "use-debounce";
 import { SearchOutlined } from "@ant-design/icons";
-import { CompanyOption } from "../../types/types";
-import { CustomerService } from "../../api/services/customer.service";
+import { CompanyOption } from "@/types/types";
+import { CustomerService } from "@/api/services/customer.service";
 
 interface CompanySearchSelectProps {
   value?: CompanyOption | string;

--- a/src/components/general/IntervalInput.tsx
+++ b/src/components/general/IntervalInput.tsx
@@ -7,8 +7,8 @@ import React, {
 } from "react";
 import { Form, Input } from "antd";
 import type { FormItemProps } from "antd";
-import { intervalInputRules } from "../../util/rules";
-import type { IntervalValue } from "../../types/types";
+import { intervalInputRules } from "@/util/rules";
+import type { IntervalValue } from "@/types/types";
 
 const DELIMITER = "~";
 

--- a/src/components/general/IntervalInput1.tsx
+++ b/src/components/general/IntervalInput1.tsx
@@ -7,8 +7,8 @@ import React, {
 } from "react";
 import { Form, Input } from "antd";
 import type { FormItemProps } from "antd";
-import { intervalInputRules } from "../../util/rules";
-import type { IntervalValue } from "../../types/types";
+import { intervalInputRules } from "@/util/rules";
+import type { IntervalValue } from "@/types/types";
 
 const DELIMITER = "~";
 

--- a/src/components/general/LevelInputNumber.tsx
+++ b/src/components/general/LevelInputNumber.tsx
@@ -1,6 +1,6 @@
 import type { IntervalInputProps } from "./IntervalInput";
 import { IntervalInput } from "./IntervalInput";
-import type { IntervalValue } from "../../types/types";
+import type { IntervalValue } from "@/types/types";
 
 export interface LevelValue {
   level: string;

--- a/src/components/general/MaterialSelect.tsx
+++ b/src/components/general/MaterialSelect.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Select } from "antd";
-import { selectOptions } from "../../util/valueUtil";
+import { selectOptions } from "@/util/valueUtil";
 
 interface MaterialSelectProps {
   id?: string;

--- a/src/components/general/MemberAvatar.tsx
+++ b/src/components/general/MemberAvatar.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from "react";
 import { Avatar, Button, Popover, Tag } from "antd";
 import type { PopoverProps } from "antd";
-import { useMemberStore } from "../../store/useMemberStore";
-import { getLocation } from "../../util/wecom";
+import { useMemberStore } from "@/store/useMemberStore";
+import { getLocation } from "@/util/wecom";
 
 interface Member {
   id: string;

--- a/src/components/general/MemberSelect.tsx
+++ b/src/components/general/MemberSelect.tsx
@@ -4,7 +4,7 @@ import type { SelectProps } from "antd";
 import { useDebounce } from "use-debounce";
 import MemberAvatar from "./MemberAvatar"; // 假设你已经实现了这个组件
 import { pinyin } from "pinyin-pro"; // 用于拼音搜索
-import { useMemberStore } from "../../store/useMemberStore";
+import { useMemberStore } from "@/store/useMemberStore";
 
 const { Text } = Typography;
 

--- a/src/components/general/MoneyInput.tsx
+++ b/src/components/general/MoneyInput.tsx
@@ -1,6 +1,6 @@
 import { InputNumber, InputNumberProps, Select } from "antd";
-import { useQuoteStore } from "../../store/useQuoteStore";
-import { formatPrice } from "../../util/valueUtil";
+import { useQuoteStore } from "@/store/useQuoteStore";
+import { formatPrice } from "@/util/valueUtil";
 interface MoneyInputProps extends Omit<InputNumberProps, "value" | "onChange"> {
   quoteId: number;
   value?: number;

--- a/src/components/general/TagAutoComplete copy.tsx
+++ b/src/components/general/TagAutoComplete copy.tsx
@@ -4,7 +4,7 @@ import type { AutoCompleteProps, InputRef } from "antd";
 import { AutoComplete, Flex, Input, Tag, theme } from "antd";
 import { TweenOneGroup } from "rc-tween-one";
 import { SelectProps } from "antd/lib";
-import { selectOptions } from "../../util/valueUtil";
+import { selectOptions } from "@/util/valueUtil";
 
 interface MaterialSelectProps {
   id?: string;

--- a/src/components/quote/AddHistoryModal.tsx
+++ b/src/components/quote/AddHistoryModal.tsx
@@ -1,7 +1,7 @@
 import { Modal, Input, DatePicker, Form, Button, Row, Col, App } from "antd";
-import { CustomerService } from "../../api/services/customer.service";
+import { CustomerService } from "@/api/services/customer.service";
 import CompanySearchSelect from "../general/CompanySearchSelect";
-import { useQuoteStore } from "../../store/useQuoteStore";
+import { useQuoteStore } from "@/store/useQuoteStore";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import MemberSelect from "../general/MemberSelect";

--- a/src/components/quote/ContractTab.tsx
+++ b/src/components/quote/ContractTab.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Form, Switch, Button } from "antd";
 import TermsTable from "./TermsTable";
-import { Clause } from "../../types/types";
+import { Clause } from "@/types/types";
 
 interface ContractTabProps {
   value: Clause[];

--- a/src/components/quote/DesktopQuoteItemsTable.tsx
+++ b/src/components/quote/DesktopQuoteItemsTable.tsx
@@ -1,11 +1,11 @@
 import { Button, Typography, App, Tooltip, Dropdown } from "antd";
 import { PlusOutlined, DeleteOutlined, LinkOutlined } from "@ant-design/icons";
-import { useQuoteStore } from "../../store/useQuoteStore";
+import { useQuoteStore } from "@/store/useQuoteStore";
 import ProductCascader from "./ProductCascader";
-import { formatPrice } from "../../util/valueUtil";
-import { isTextSelecting } from "../../util/domUtil";
+import { formatPrice } from "@/util/valueUtil";
+import { isTextSelecting } from "@/util/domUtil";
 import ProductConfigModal from "./ProductConfigForm/ProductConfigModal";
-import { QuoteItem } from "../../types/types";
+import { QuoteItem } from "@/types/types";
 import { useMemo, useState } from "react";
 import SortableTable, { DragHandle } from "../general/SortableTable";
 import { SortableColumn } from "../general/SortableColumn";

--- a/src/components/quote/ProductCascader.tsx
+++ b/src/components/quote/ProductCascader.tsx
@@ -2,11 +2,11 @@ import { Cascader, Spin } from "antd";
 import type { CascaderProps } from "antd";
 import * as _ from "lodash-es";
 import { useEffect, useMemo, useState } from "react";
-import { useQuoteStore } from "../../store/useQuoteStore";
+import { useQuoteStore } from "@/store/useQuoteStore";
 import { SizeType } from "antd/es/config-provider/SizeContext";
 import { camelCase, groupBy, filter, map, isEmpty } from "lodash-es";
-import { ProductCategory } from "../../types/types";
-import { useProductStore } from "../../store/useProductStore";
+import { ProductCategory } from "@/types/types";
+import { useProductStore } from "@/store/useProductStore";
 interface ProductCascaderProps {
   value?: string | string[];
   style?: React.CSSProperties;

--- a/src/components/quote/ProductConfigForm/ImportProductModal.tsx
+++ b/src/components/quote/ProductConfigForm/ImportProductModal.tsx
@@ -1,16 +1,16 @@
 import React, { useEffect, useState } from "react";
 import { Modal, Tabs, Table, Button } from "antd";
-import { ProductService } from "../../../api/services/product.service";
+import { ProductService } from "@/api/services/product.service";
 import ProductConfigurationForm from "./ProductConfigurationForm";
-import ProductSearchBar from "../../general/ProductSearchBar";
+import ProductSearchBar from "@/general/ProductSearchBar";
 import {
   QuoteItem,
   ProductSearchResult,
   QuoteTemplate,
-} from "../../../types/types";
-import { useTemplateStore } from "../../../store/useTemplateStore";
-import TemplateTable from "../../template/TemplateTable";
-import TemplateCreateModal from "../../template/TemplateCreateModal";
+} from "@/types/types";
+import { useTemplateStore } from "@/store/useTemplateStore";
+import TemplateTable from "@/template/TemplateTable";
+import TemplateCreateModal from "@/template/TemplateCreateModal";
 
 interface ImportProductModalProps {
   open: boolean;

--- a/src/components/quote/ProductConfigForm/ProductConfigModal.tsx
+++ b/src/components/quote/ProductConfigForm/ProductConfigModal.tsx
@@ -1,10 +1,10 @@
 import { Modal, Button, Skeleton } from "antd";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { useQuoteStore } from "../../../store/useQuoteStore";
+import { useQuoteStore } from "@/store/useQuoteStore";
 import { FormInstance } from "antd/lib";
 import ProductConfigurationForm from "./ProductConfigurationForm";
 import { CheckOutlined, EditOutlined } from "@ant-design/icons";
-import { QuoteItem } from "../../../types/types";
+import { QuoteItem } from "@/types/types";
 import ImportProductModal from "./ImportProductModal";
 
 interface ProductConfigModalProps {

--- a/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
+++ b/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
@@ -7,11 +7,11 @@ import {
   useRef,
   useState,
 } from "react";
-import PriceForm from "../../quoteForm/PriceForm";
-import { QuoteItem, QuoteTemplate } from "../../../types/types";
+import PriceForm from "@/quoteForm/PriceForm";
+import { QuoteItem, QuoteTemplate } from "@/types/types";
 
 import { getFormByCategory, ModelFormRef } from "./formSelector";
-import { useQuoteStore } from "../../../store/useQuoteStore";
+import { useQuoteStore } from "@/store/useQuoteStore";
 
 interface ProductConfigurationFormProps {
   quoteItem?: QuoteItem;

--- a/src/components/quote/ProductConfigForm/formSelector.tsx
+++ b/src/components/quote/ProductConfigForm/formSelector.tsx
@@ -1,13 +1,13 @@
 import React, { RefObject } from "react";
-import DieForm from "../../quoteForm/dieForm/DieForm";
-import SmartRegulator from "../../quoteForm/SmartRegulator";
-import MeteringPumpForm from "../../quoteForm/MeteringPumpForm/MeteringPumpForm";
-import FeedblockForm from "../../quoteForm/FeedblockForm/FeedblockForm";
-import FilterForm from "../../quoteForm/FilterForm/FilterForm";
-import ThicknessGaugeForm from "../../quoteForm/ThicknessGaugeForm/ThicknessGaugeForm";
-import HydraulicStationForm from "../../quoteForm/HydraulicStationForm/HydraulicStationForm";
-import PartsForm from "../../quoteForm/PartsForm";
-import { OtherForm } from "../../quoteForm/OtherForm";
+import DieForm from "@/quoteForm/dieForm/DieForm";
+import SmartRegulator from "@/quoteForm/SmartRegulator";
+import MeteringPumpForm from "@/quoteForm/MeteringPumpForm/MeteringPumpForm";
+import FeedblockForm from "@/quoteForm/FeedblockForm/FeedblockForm";
+import FilterForm from "@/quoteForm/FilterForm/FilterForm";
+import ThicknessGaugeForm from "@/quoteForm/ThicknessGaugeForm/ThicknessGaugeForm";
+import HydraulicStationForm from "@/quoteForm/HydraulicStationForm/HydraulicStationForm";
+import PartsForm from "@/quoteForm/PartsForm";
+import { OtherForm } from "@/quoteForm/OtherForm";
 
 export type ModelFormRef = RefObject<{ form: any } | null>;
 

--- a/src/components/quote/QuoteConfigTab.tsx
+++ b/src/components/quote/QuoteConfigTab.tsx
@@ -17,8 +17,8 @@ import AddressInput from "../general/AddressInput";
 import { CustomSelect } from "../general/CustomSelect";
 import { MoneyInput } from "../general/MoneyInput";
 import QuoteItemsTable from "./QuoteItemsTable";
-import { Quote } from "../../types/types";
-import { selectOptions } from "../../util/valueUtil";
+import { Quote } from "@/types/types";
+import { selectOptions } from "@/util/valueUtil";
 
 const INDUSTRY = {
   新能源及储能: ["动力电池（锂电、氢燃料、钠电）", "光伏新能源"],

--- a/src/components/quote/QuoteForm.tsx
+++ b/src/components/quote/QuoteForm.tsx
@@ -1,13 +1,13 @@
 // components/quote/QuoteForm.tsx
 import React, { useState, useEffect, useRef } from "react";
 import { Form, Button, Tabs, App, Row, Col, Dropdown, MenuProps } from "antd";
-import { Quote, Clause } from "../../types/types";
+import { Quote, Clause } from "@/types/types";
 import QuoteConfigTab from "./QuoteConfigTab";
 import QuoteTermsTab from "./QuoteTermsTab";
 import ContractTab from "./ContractTab";
 import { debounce, throttle } from "lodash-es";
-import { useQuoteStore } from "../../store/useQuoteStore";
-import { CustomerService } from "../../api/services/customer.service";
+import { useQuoteStore } from "@/store/useQuoteStore";
+import { CustomerService } from "@/api/services/customer.service";
 import { DownOutlined } from "@ant-design/icons";
 
 const getDefaultQuoteTerms = (days: number): Clause[] => [

--- a/src/components/quote/QuoteItemsTable.tsx
+++ b/src/components/quote/QuoteItemsTable.tsx
@@ -1,10 +1,10 @@
 import { isMobile } from "react-device-detect"; // 使用设备检测库
 import * as _ from "lodash";
-import { useQuoteStore } from "../../store/useQuoteStore";
+import { useQuoteStore } from "@/store/useQuoteStore";
 import DesktopQuoteItemsTable from "./DesktopQuoteItemsTable";
-import { QuoteItem } from "../../types/types";
+import { QuoteItem } from "@/types/types";
 import { App } from "antd";
-import useProductActionModal from "../../hook/showProductActionModal";
+import useProductActionModal from "@/hook/showProductActionModal";
 interface QuoteItemsTableProps {
   quoteId: number;
   id?: string;

--- a/src/components/quote/QuoteModal.tsx
+++ b/src/components/quote/QuoteModal.tsx
@@ -3,8 +3,8 @@ import React, { useEffect, useState } from "react";
 import { Modal, Button, Form, App } from "antd";
 import { FullscreenOutlined, FullscreenExitOutlined } from "@ant-design/icons";
 import QuoteForm from "./QuoteForm";
-import type { Quote } from "../../types/types";
-import { useQuoteStore } from "../../store/useQuoteStore";
+import type { Quote } from "@/types/types";
+import { useQuoteStore } from "@/store/useQuoteStore";
 import dayjs from "dayjs";
 import { Skeleton } from "antd";
 interface QuoteModalProps {

--- a/src/components/quote/QuoteTable.tsx
+++ b/src/components/quote/QuoteTable.tsx
@@ -10,8 +10,8 @@ import { Table, Tag, Form, Input } from "antd";
 import type { ColumnsType, TablePaginationConfig } from "antd/es/table";
 import MemberAvatar from "../general/MemberAvatar";
 import QuoteModal from "./QuoteModal";
-import { useQuoteStore } from "../../store/useQuoteStore";
-import { isTextSelecting } from "../../util/domUtil";
+import { useQuoteStore } from "@/store/useQuoteStore";
+import { isTextSelecting } from "@/util/domUtil";
 
 interface QuoteTableProps {
   type: string; // 'history' | 'oa'

--- a/src/components/quote/QuoteTermsTab.tsx
+++ b/src/components/quote/QuoteTermsTab.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button } from "antd";
 import TermsTable from "./TermsTable";
-import { Clause } from "../../types/types";
+import { Clause } from "@/types/types";
 
 interface QuoteTermsTabProps {
   value: Clause[];

--- a/src/components/quote/TermsTable.tsx
+++ b/src/components/quote/TermsTable.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Button, Input } from "antd";
 import { EditOutlined, DeleteOutlined, PlusOutlined } from "@ant-design/icons";
 import SortableTable, { DragHandle } from "../general/SortableTable";
-import { Clause } from "../../types/types";
+import { Clause } from "@/types/types";
 
 interface TermsTableProps {
   value: Clause[];

--- a/src/components/quoteForm/FeedblockForm/FeedblockForm.tsx
+++ b/src/components/quoteForm/FeedblockForm/FeedblockForm.tsx
@@ -19,15 +19,15 @@ import ProForm, {
 } from "@ant-design/pro-form";
 import TextArea from "antd/es/input/TextArea";
 
-import MaterialSelect from "../../general/MaterialSelect";
-import AutoSlashInput from "../../general/AutoSlashInput";
-import RatioInput from "../../general/RatioInput";
-import LevelInputNumber, { LevelValue } from "../../general/LevelInputNumber";
+import MaterialSelect from "@/general/MaterialSelect";
+import AutoSlashInput from "@/general/AutoSlashInput";
+import RatioInput from "@/general/RatioInput";
+import LevelInputNumber, { LevelValue } from "@/general/LevelInputNumber";
 import ExtruderForm from "../formComponents/ExtruderForm";
 import { PowerInput } from "../formComponents/PowerInput";
 import { HeatingMethodSelect } from "../formComponents/HeatingMethodInput";
 import ProFormListWrapper from "../formComponents/ProFormListWrapper";
-import { CustomSelect } from "../../general/CustomSelect";
+import { CustomSelect } from "@/general/CustomSelect";
 
 interface PriceFormRef {
   form: FormInstance;

--- a/src/components/quoteForm/FilterForm/FilterForm.tsx
+++ b/src/components/quoteForm/FilterForm/FilterForm.tsx
@@ -2,13 +2,13 @@ import { AutoComplete, Col, Form, InputNumber, Radio, Row } from "antd";
 
 import ProForm from "@ant-design/pro-form";
 import { forwardRef, useEffect, useImperativeHandle } from "react";
-import { IntervalInputFormItem } from "../../general/IntervalInput";
-import MaterialSelect from "../../general/MaterialSelect";
+import { IntervalInputFormItem } from "@/general/IntervalInput";
+import MaterialSelect from "@/general/MaterialSelect";
 import { PowerInput } from "../formComponents/PowerInput";
 import { HeatingMethodSelect } from "../formComponents/HeatingMethodInput";
-import { useProductStore } from "../../../store/useProductStore";
-import { useQuoteStore } from "../../../store/useQuoteStore";
-import useProductActionModal from "../../../hook/showProductActionModal";
+import { useProductStore } from "@/store/useProductStore";
+import { useQuoteStore } from "@/store/useQuoteStore";
+import useProductActionModal from "@/hook/showProductActionModal";
 
 import FilterSelection from "./FilterSelection";
 import TextArea from "antd/es/input/TextArea";

--- a/src/components/quoteForm/FilterForm/FilterSelection.tsx
+++ b/src/components/quoteForm/FilterForm/FilterSelection.tsx
@@ -1,6 +1,6 @@
 import { ProCard } from "@ant-design/pro-components";
 import { Col, Form, Input, Row, Select, FormInstance } from "antd";
-import { FilterProduct } from "../../../types/types";
+import { FilterProduct } from "@/types/types";
 
 interface Props {
   form: FormInstance;

--- a/src/components/quoteForm/HydraulicStationForm/HydraulicStationForm.tsx
+++ b/src/components/quoteForm/HydraulicStationForm/HydraulicStationForm.tsx
@@ -10,7 +10,7 @@ import {
 import { forwardRef, useImperativeHandle } from "react";
 import ProForm from "@ant-design/pro-form";
 import { PowerInput } from "../formComponents/PowerInput";
-import { useQuoteStore } from "../../../store/useQuoteStore";
+import { useQuoteStore } from "@/store/useQuoteStore";
 
 interface HydraulicStationFormProps {
   quoteId: number;

--- a/src/components/quoteForm/MeteringPumpForm/MeteringPumpForm.tsx
+++ b/src/components/quoteForm/MeteringPumpForm/MeteringPumpForm.tsx
@@ -8,12 +8,12 @@ import { SurfaceTreatment } from "../dieForm/SurfaceTreatment";
 import { SameProduct } from "../dieForm/SameProduct";
 import ProForm from "@ant-design/pro-form";
 import TextArea from "antd/es/input/TextArea";
-import useProductActionModal from "../../../hook/showProductActionModal";
-import { useQuoteStore } from "../../../store/useQuoteStore";
+import useProductActionModal from "@/hook/showProductActionModal";
+import { useQuoteStore } from "@/store/useQuoteStore";
 import { ModelSelection } from "./ModelSelection";
-import { useProductStore } from "../../../store/useProductStore";
+import { useProductStore } from "@/store/useProductStore";
 import { ModelOption } from "./ModelOption";
-import { parseNumber } from "../../../util/valueUtil";
+import { parseNumber } from "@/util/valueUtil";
 interface PriceFormRef {
   form: FormInstance; // 明确定义暴露的form实例
 }

--- a/src/components/quoteForm/MeteringPumpForm/ModelOption.tsx
+++ b/src/components/quoteForm/MeteringPumpForm/ModelOption.tsx
@@ -13,19 +13,19 @@ import {
   Select,
   Tag,
 } from "antd";
-import { IntervalInputFormItem } from "../../general/IntervalInput";
-import { CustomSelect } from "../../general/CustomSelect";
+import { IntervalInputFormItem } from "@/general/IntervalInput";
+import { CustomSelect } from "@/general/CustomSelect";
 import { useEffect, useState } from "react";
 import ScrewForm from "../formComponents/ScrewForm";
-import AutoSlashInput from "../../general/AutoSlashInput";
-import RatioInput from "../../general/RatioInput";
-import { MATERIAL } from "../../../util/MATERIAL";
-import { useProductStore } from "../../../store/useProductStore";
+import AutoSlashInput from "@/general/AutoSlashInput";
+import RatioInput from "@/general/RatioInput";
+import { MATERIAL } from "@/util/MATERIAL";
+import { useProductStore } from "@/store/useProductStore";
 import ExtruderForm from "../formComponents/ExtruderForm";
-import { CheckableTagGroup } from "../../general/CheckableTagGroup";
+import { CheckableTagGroup } from "@/general/CheckableTagGroup";
 import { HeatingMethodSelect } from "../formComponents/HeatingMethodInput";
 import { PowerInput } from "../formComponents/PowerInput";
-import { inputRule } from "../../../util/rules";
+import { inputRule } from "@/util/rules";
 
 const tagsData = ["泵体", "传动系统", "控制系统"];
 export const ModelOption = () => {

--- a/src/components/quoteForm/MeteringPumpForm/ModelSelection.tsx
+++ b/src/components/quoteForm/MeteringPumpForm/ModelSelection.tsx
@@ -10,15 +10,15 @@ import {
   Segmented,
   Select,
 } from "antd";
-import { IntervalInputFormItem } from "../../general/IntervalInput";
-import { CustomSelect } from "../../general/CustomSelect";
+import { IntervalInputFormItem } from "@/general/IntervalInput";
+import { CustomSelect } from "@/general/CustomSelect";
 import { useEffect, useState } from "react";
 import ScrewForm from "../formComponents/ScrewForm";
-import AutoSlashInput from "../../general/AutoSlashInput";
-import RatioInput from "../../general/RatioInput";
-import { MATERIAL } from "../../../util/MATERIAL";
-import MaterialSelect from "../../general/MaterialSelect";
-import { useProductStore } from "../../../store/useProductStore";
+import AutoSlashInput from "@/general/AutoSlashInput";
+import RatioInput from "@/general/RatioInput";
+import { MATERIAL } from "@/util/MATERIAL";
+import MaterialSelect from "@/general/MaterialSelect";
+import { useProductStore } from "@/store/useProductStore";
 import ExtruderForm from "../formComponents/ExtruderForm";
 
 export const ModelSelection = () => {

--- a/src/components/quoteForm/PartsForm.tsx
+++ b/src/components/quoteForm/PartsForm.tsx
@@ -10,7 +10,7 @@ import {
 } from "antd";
 import ProForm, { ProFormList, ProFormDependency } from "@ant-design/pro-form";
 import { forwardRef, useImperativeHandle } from "react";
-import { formatPrice } from "../../util/valueUtil";
+import { formatPrice } from "@/util/valueUtil";
 
 interface PartFormRef {
   form: FormInstance;

--- a/src/components/quoteForm/PriceForm.tsx
+++ b/src/components/quoteForm/PriceForm.tsx
@@ -10,7 +10,7 @@ import {
 } from "antd";
 import { forwardRef, useImperativeHandle } from "react";
 import InputWithButton from "../general/InputWithButton";
-import { formatPrice } from "../../util/valueUtil";
+import { formatPrice } from "@/util/valueUtil";
 interface PriceFormRef {
   form: FormInstance; // 明确定义暴露的form实例
 }

--- a/src/components/quoteForm/SmartRegulator.tsx
+++ b/src/components/quoteForm/SmartRegulator.tsx
@@ -1,13 +1,13 @@
 import { Col, Form, FormInstance, Input, Radio, Row } from "antd";
 import { forwardRef, useImperativeHandle, useState } from "react";
-import useProductActionModal from "../../hook/showProductActionModal";
-import { useQuoteStore } from "../../store/useQuoteStore";
+import useProductActionModal from "@/hook/showProductActionModal";
+import { useQuoteStore } from "@/store/useQuoteStore";
 
 import TextArea from "antd/es/input/TextArea";
 import ProForm from "@ant-design/pro-form";
 import CustomRadioGroup from "../general/CustomRadioGroup";
 import { TooltipLabel } from "../general/TooltipLabel";
-import { RadioWithInputRules } from "../../util/rules";
+import { RadioWithInputRules } from "@/util/rules";
 interface PriceFormRef {
   form: FormInstance; // 明确定义暴露的form实例
 }

--- a/src/components/quoteForm/dieForm/DieBody.tsx
+++ b/src/components/quoteForm/dieForm/DieBody.tsx
@@ -1,8 +1,8 @@
 import { ProCard } from "@ant-design/pro-components";
 import { Badge, Col, Form, Radio, Row } from "antd";
-import { CustomSelect } from "../../general/CustomSelect";
-import { AutoCompleteInput } from "../../general/AutoCompleteInput";
-import { MATERIAL_OPTIONS } from "../../../util/MATERIAL";
+import { CustomSelect } from "@/general/CustomSelect";
+import { AutoCompleteInput } from "@/general/AutoCompleteInput";
+import { MATERIAL_OPTIONS } from "@/util/MATERIAL";
 
 // 常量定义
 const UPPER_LIP_OPTIONS = {

--- a/src/components/quoteForm/dieForm/DieForm.tsx
+++ b/src/components/quoteForm/dieForm/DieForm.tsx
@@ -8,9 +8,9 @@ import { SurfaceTreatment } from "./SurfaceTreatment";
 import { SameProduct } from "./SameProduct";
 import ProForm from "@ant-design/pro-form";
 import TextArea from "antd/es/input/TextArea";
-import useProductActionModal from "../../../hook/showProductActionModal";
-import { useQuoteStore } from "../../../store/useQuoteStore";
-import { LevelValue } from "../../general/LevelInputNumber";
+import useProductActionModal from "@/hook/showProductActionModal";
+import { useQuoteStore } from "@/store/useQuoteStore";
+import { LevelValue } from "@/general/LevelInputNumber";
 interface PriceFormRef {
   form: FormInstance; // 明确定义暴露的form实例
 }

--- a/src/components/quoteForm/dieForm/DieInstall.tsx
+++ b/src/components/quoteForm/dieForm/DieInstall.tsx
@@ -1,8 +1,8 @@
 import { ProCard } from "@ant-design/pro-components";
 import { Col, Form, InputNumber, Radio, Row, Space, Tooltip } from "antd";
-import { RadioWithInputRules } from "../../../util/rules";
-import { CustomSelect } from "../../general/CustomSelect";
-import { RadioWithInput } from "../../general/RadioWithInput";
+import { RadioWithInputRules } from "@/util/rules";
+import { CustomSelect } from "@/general/CustomSelect";
+import { RadioWithInput } from "@/general/RadioWithInput";
 import { QuestionCircleOutlined } from "@ant-design/icons";
 
 // 常量定义

--- a/src/components/quoteForm/dieForm/Product.tsx
+++ b/src/components/quoteForm/dieForm/Product.tsx
@@ -4,13 +4,13 @@ import {
   ProFormDependency,
 } from "@ant-design/pro-components";
 import { Col, Form, Input, InputNumber, Radio, Row } from "antd";
-import { IntervalInputFormItem } from "../../general/IntervalInput";
-import { CustomSelect } from "../../general/CustomSelect";
+import { IntervalInputFormItem } from "@/general/IntervalInput";
+import { CustomSelect } from "@/general/CustomSelect";
 import ScrewForm from "../formComponents/ScrewForm";
-import AutoSlashInput from "../../general/AutoSlashInput";
+import AutoSlashInput from "@/general/AutoSlashInput";
 import ProFormListWrapper from "../formComponents/ProFormListWrapper";
-import LevelInputNumber, { LevelValue } from "../../general/LevelInputNumber";
-import MaterialSelect from "../../general/MaterialSelect";
+import LevelInputNumber, { LevelValue } from "@/general/LevelInputNumber";
+import MaterialSelect from "@/general/MaterialSelect";
 
 const RUNNER_NUMBER_OPTIONS = {
   流道形式: ["单腔流道", "模内共挤", "分配器共挤", "分配器+模内共挤"],

--- a/src/components/quoteForm/dieForm/SurfaceTreatment.tsx
+++ b/src/components/quoteForm/dieForm/SurfaceTreatment.tsx
@@ -3,11 +3,11 @@ import { AutoComplete, Col, Form, Radio, Row } from "antd";
 import {
   autoCompleteIntervalInputRules,
   RadioWithInputRules,
-} from "../../../util/rules";
-import { RadioWithInput } from "../../general/RadioWithInput";
-import { AutoCompleteIntervalInput } from "../../general/AutoCompleteIntervalInput";
+} from "@/util/rules";
+import { RadioWithInput } from "@/general/RadioWithInput";
+import { AutoCompleteIntervalInput } from "@/general/AutoCompleteIntervalInput";
 import TextArea from "antd/es/input/TextArea";
-import { IntervalInput1 } from "../../general/IntervalInput1";
+import { IntervalInput1 } from "@/general/IntervalInput1";
 
 // 常量定义
 const precisionLevelOptions = [

--- a/src/components/quoteForm/dieForm/TemperatureControl.tsx
+++ b/src/components/quoteForm/dieForm/TemperatureControl.tsx
@@ -9,10 +9,10 @@ import {
   Radio,
   Row,
 } from "antd";
-import { powerInputRules } from "../../../util/rules";
+import { powerInputRules } from "@/util/rules";
 import { PowerInput } from "../formComponents/PowerInput";
 import { HeatingMethodSelect } from "../formComponents/HeatingMethodInput";
-import { TooltipLabel } from "../../general/TooltipLabel";
+import { TooltipLabel } from "@/general/TooltipLabel";
 import { useState } from "react";
 
 export const TemperatureControl = () => {

--- a/src/components/quoteForm/formComponents/DieWidthInput.tsx
+++ b/src/components/quoteForm/formComponents/DieWidthInput.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Select, Space, Form } from "antd";
 import type { SelectProps, FormItemProps } from "antd";
-import { IntervalInput, IntervalInputProps } from "../../general/IntervalInput"; // 假设IntervalInput已实现
+import { IntervalInput, IntervalInputProps } from "@/general/IntervalInput"; // 假设IntervalInput已实现
 
 const { Option } = Select;
 

--- a/src/components/quoteForm/formComponents/ExtruderFormItem.tsx
+++ b/src/components/quoteForm/formComponents/ExtruderFormItem.tsx
@@ -1,7 +1,7 @@
 import ProForm from "@ant-design/pro-form";
 import { AutoComplete, Col, Form, InputNumber, Row, Select } from "antd";
 import { DefaultOptionType } from "antd/es/select";
-import { IntervalInput } from "../../general/IntervalInput";
+import { IntervalInput } from "@/general/IntervalInput";
 
 export const ExtruderFormItem = ({ items }: { items: string[] }) => {
   return (

--- a/src/components/quoteForm/formComponents/MeshBeltSpecItem.tsx
+++ b/src/components/quoteForm/formComponents/MeshBeltSpecItem.tsx
@@ -1,6 +1,6 @@
 import ProForm from "@ant-design/pro-form";
 import { Row, Col, InputNumber, Layout } from "antd";
-import { AutoCompleteInput } from "../../general/AutoCompleteInput";
+import { AutoCompleteInput } from "@/general/AutoCompleteInput";
 
 const MeshBeltSpecItem: React.FC = () => {
   return (

--- a/src/components/quoteForm/formComponents/PowerInput.tsx
+++ b/src/components/quoteForm/formComponents/PowerInput.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Input, Select, Space, Form, InputNumber, AutoComplete } from "antd";
 import type { FormItemProps } from "antd";
 import { Rule } from "antd/es/form";
-import { AutoCompleteInput } from "../../general/AutoCompleteInput";
+import { AutoCompleteInput } from "@/general/AutoCompleteInput";
 
 const { Option } = Select;
 

--- a/src/components/quoteForm/formComponents/ScrewFormItem.tsx
+++ b/src/components/quoteForm/formComponents/ScrewFormItem.tsx
@@ -1,7 +1,7 @@
 import ProForm from "@ant-design/pro-form";
 import { AutoComplete, Col, Form, InputNumber, Row, Select } from "antd";
 import { DefaultOptionType } from "antd/es/select";
-import { IntervalInput } from "../../general/IntervalInput";
+import { IntervalInput } from "@/general/IntervalInput";
 
 export const ScrewFormItem = ({ items }: { items: string[] }) => {
   return (

--- a/src/components/template/TemplateCreate.tsx
+++ b/src/components/template/TemplateCreate.tsx
@@ -11,7 +11,7 @@ import { CustomSelect } from "../general/CustomSelect";
 
 import { getFormByCategory } from "../quote/ProductConfigForm/formSelector";
 
-import { QuoteTemplate } from "../../types/types";
+import { QuoteTemplate } from "@/types/types";
 import TextArea from "antd/es/input/TextArea";
 
 export interface TemplateCreateRef {

--- a/src/components/template/TemplateCreateModal.tsx
+++ b/src/components/template/TemplateCreateModal.tsx
@@ -1,8 +1,8 @@
 import React, { useRef, useState } from "react";
 import { Modal, Button } from "antd";
 import TemplateCreate, { TemplateCreateRef } from "./TemplateCreate";
-import { TemplateService } from "../../api/services/template.service";
-import { useTemplateStore } from "../../store/useTemplateStore";
+import { TemplateService } from "@/api/services/template.service";
+import { useTemplateStore } from "@/store/useTemplateStore";
 
 interface TemplateCreateModalProps {
   open: boolean;

--- a/src/components/template/TemplateFormModal.tsx
+++ b/src/components/template/TemplateFormModal.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from "react";
 import { Modal, Button } from "antd";
 import ProductConfigurationForm from "../quote/ProductConfigForm/ProductConfigurationForm";
-import { QuoteTemplate } from "../../types/types";
-import { useTemplateStore } from "../../store/useTemplateStore";
-import { TemplateService } from "../../api/services/template.service";
+import { QuoteTemplate } from "@/types/types";
+import { useTemplateStore } from "@/store/useTemplateStore";
+import { TemplateService } from "@/api/services/template.service";
 
 interface TemplateFormModalProps {
   open: boolean;

--- a/src/components/template/TemplateTable.tsx
+++ b/src/components/template/TemplateTable.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Table } from "antd";
 import MemberAvatar from "../general/MemberAvatar";
-import { QuoteTemplate } from "../../types/types";
+import { QuoteTemplate } from "@/types/types";
 
 interface TemplateTableProps {
   templates: QuoteTemplate[];

--- a/src/page/OpportunitySearch/index.tsx
+++ b/src/page/OpportunitySearch/index.tsx
@@ -13,14 +13,14 @@ import {
   Spin,
 } from "antd";
 import { SearchOutlined, PlusOutlined } from "@ant-design/icons";
-import OpportunityCard from "../../components/OpportunityCard";
+import OpportunityCard from "@/components/OpportunityCard";
 import styles from "./OpportunitySearchPage.module.less";
-import StatusSelector from "../../components/StatusSelector";
-import { DebounceSelect } from "../../components/general/DebounceSelect";
-import { CustomerService } from "../../api/services/customer.service";
+import StatusSelector from "@/components/StatusSelector";
+import { DebounceSelect } from "@/components/general/DebounceSelect";
+import { CustomerService } from "@/api/services/customer.service";
 import { set } from "lodash-es";
-import { OpportunityService } from "../../api/services/opportunity.service";
-import { useQuoteStore } from "../../store/useQuoteStore";
+import { OpportunityService } from "@/api/services/opportunity.service";
+import { useQuoteStore } from "@/store/useQuoteStore";
 
 const { Title, Text } = Typography;
 const { Option } = Select;

--- a/src/page/externalContact/index.tsx
+++ b/src/page/externalContact/index.tsx
@@ -19,12 +19,12 @@ import { UserOutlined, SearchOutlined } from "@ant-design/icons";
 import "./style.less";
 import * as ww from "@wecom/jssdk";
 import Layout, { Content } from "antd/es/layout/layout";
-import { CustomerService } from "../../api/services/customer.service";
-import { DebounceSelect } from "../../components/general/DebounceSelect";
-import { AuthService } from "../../api/services/auth.service";
+import { CustomerService } from "@/api/services/customer.service";
+import { DebounceSelect } from "@/components/general/DebounceSelect";
+import { AuthService } from "@/api/services/auth.service";
 import { values } from "lodash";
-import { useAuthStore } from "../../store/useAuthStore";
-import { getContext, register } from "../../util/wecom";
+import { useAuthStore } from "@/store/useAuthStore";
+import { getContext, register } from "@/util/wecom";
 
 const { Option } = Select;
 

--- a/src/page/quote/HistoryQuoteTablePage.tsx
+++ b/src/page/quote/HistoryQuoteTablePage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Typography } from "antd";
-import QuoteTable from "../../components/quote/QuoteTable";
-import { AddHistoryModal } from "../../components/quote/AddHistoryModal";
+import QuoteTable from "@/components/quote/QuoteTable";
+import { AddHistoryModal } from "@/components/quote/AddHistoryModal";
 
 const HistoryQuoteTablePage: React.FC = () => {
   return (

--- a/src/page/quote/OAQuoteTablePage.tsx
+++ b/src/page/quote/OAQuoteTablePage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Typography } from "antd";
-import QuoteTable from "../../components/quote/QuoteTable";
+import QuoteTable from "@/components/quote/QuoteTable";
 
 const OAQuoteTablePage: React.FC = () => {
   return (

--- a/src/page/quote/QuoteFormPage.tsx
+++ b/src/page/quote/QuoteFormPage.tsx
@@ -1,12 +1,12 @@
 // pages/QuoteFormPage.tsx
 import React, { useEffect, useState } from "react";
 import { Button, App, Modal } from "antd";
-import { useQuoteStore } from "../../store/useQuoteStore";
+import { useQuoteStore } from "@/store/useQuoteStore";
 import { useNavigate, useParams } from "react-router-dom";
 import dayjs from "dayjs";
 import { debounce, throttle } from "lodash-es";
 import { Form } from "antd";
-import QuoteForm from "../../components/quote/QuoteForm";
+import QuoteForm from "@/components/quote/QuoteForm";
 
 const QuoteFormPage = () => {
   const { id } = useParams<{ id: string }>();

--- a/src/page/template/TemplateCreatePage.tsx
+++ b/src/page/template/TemplateCreatePage.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Button, App } from "antd";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
-import TemplateCreate, { TemplateCreateRef } from "../../components/template/TemplateCreate";
-import { TemplateService } from "../../api/services/template.service";
-import { useTemplateStore } from "../../store/useTemplateStore";
-import { QuoteTemplate } from "../../types/types";
+import TemplateCreate, { TemplateCreateRef } from "@/components/template/TemplateCreate";
+import { TemplateService } from "@/api/services/template.service";
+import { useTemplateStore } from "@/store/useTemplateStore";
+import { QuoteTemplate } from "@/types/types";
 
 const TemplateCreatePage: React.FC = () => {
   const { id } = useParams<{ id: string }>();

--- a/src/page/template/TemplateFormPage.tsx
+++ b/src/page/template/TemplateFormPage.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { Button, App } from "antd";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
-import ProductConfigurationForm from "../../components/quote/ProductConfigForm/ProductConfigurationForm";
-import { QuoteTemplate } from "../../types/types";
-import { useTemplateStore } from "../../store/useTemplateStore";
-import { TemplateService } from "../../api/services/template.service";
+import ProductConfigurationForm from "@/components/quote/ProductConfigForm/ProductConfigurationForm";
+import { QuoteTemplate } from "@/types/types";
+import { useTemplateStore } from "@/store/useTemplateStore";
+import { TemplateService } from "@/api/services/template.service";
 
 const TemplateFormPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();

--- a/src/page/template/TemplateListPage.tsx
+++ b/src/page/template/TemplateListPage.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from "react";
 import { Button } from "antd";
-import { useTemplateStore } from "../../store/useTemplateStore";
-import TemplateTable from "../../components/template/TemplateTable";
-import TemplateCreateModal from "../../components/template/TemplateCreateModal";
+import { useTemplateStore } from "@/store/useTemplateStore";
+import TemplateTable from "@/components/template/TemplateTable";
+import TemplateCreateModal from "@/components/template/TemplateCreateModal";
 
 const TemplateListPage: React.FC = () => {
   const { templates, loading, refreshTemplates, fetchTemplates } = useTemplateStore();

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,6 +21,11 @@
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
+    ,
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     // ...其他配置
-    "typeRoots": ["./node_modules/@types", "./src/types"]
+    "typeRoots": ["./node_modules/@types", "./src/types"],
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "files": [],
   "references": [

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -19,6 +19,11 @@
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
+    ,
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import vitePluginImp from "vite-plugin-imp"; // 按需加载插件
+import { fileURLToPath, URL } from "node:url";
 
 export default defineConfig({
   optimizeDeps: {
@@ -26,6 +27,11 @@ export default defineConfig({
     //   ],
     // }),
   ],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   css: {
     preprocessorOptions: {
       less: {


### PR DESCRIPTION
## Summary
- add baseUrl and alias paths to TypeScript configs
- configure Vite alias resolution
- use `@/` imports instead of long relative paths

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find type definition file for 'babel__core')*

------
https://chatgpt.com/codex/tasks/task_e_684d5a6dcb508327826e1263128d1500