### PR TITLE
Enable multi-column sorting for QuoteTable

### DIFF
--- a/src/api/services/quote.service.ts
+++ b/src/api/services/quote.service.ts
@@ -52,9 +52,14 @@ export const QuoteService = {
     type?: string;
     quoteName?: string;
     customerName?: string;
+    sorters?: { field: string; order: string }[];
   }) {
+    const { sorters, ...rest } = params || {};
+    const sortParam = sorters
+      ?.map((s) => `${s.field}:${s.order}`)
+      .join(",");
     const quote = await apiClient.get("/quote/get", {
-      params,
+      params: { ...rest, sort: sortParam },
     });
     return quote.data as { list: Quote[]; total: number };
   },

--- a/src/store/useQuoteStore.ts
+++ b/src/store/useQuoteStore.ts
@@ -63,6 +63,7 @@ interface QuotesStore {
     type?: string;
     quoteName?: string;
     customerName?: string;
+    sorters?: { field: string; order: string }[];
   }) => Promise<void>;
   fetchQuote: (quoteId: number) => Promise<Quote>;
   createQuote: (params: {


### PR DESCRIPTION
## Summary
- extend QuoteService.getQuotes to accept sorters
- support sorters param in useQuoteStore
- add multi-column server-side sorting to QuoteTable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684e9410e0b483278790d10a04f47310