### PR TITLE
Add approval info columns and column hiding prop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import MainLayout from "./components/MainLayout";
 import JdyRedirect from "./page/JdyRedirect";
 import HistoryQuoteTablePage from "./page/quote/HistoryQuoteTablePage";
 import OAQuoteTablePage from "./page/quote/OAQuoteTablePage";
+import TodoQuoteTablePage from "./page/quote/TodoQuoteTablePage";
 import QuoteFormPage from "./page/quote/QuoteFormPage";
 import TemplateListPage from "./page/template/TemplateListPage";
 import { NoPermissionPage } from "./page/NoPermissionPage";
@@ -40,6 +41,7 @@ const App: React.FC = () => {
                 <Route index element={<HistoryQuoteTablePage />} />
                 <Route path="history" element={<HistoryQuoteTablePage />} />
                 <Route path="oa" element={<OAQuoteTablePage />} />
+                <Route path="todo" element={<TodoQuoteTablePage />} />
                 <Route path=":id" element={<QuoteFormPage />} />
               </Route>
               <Route path="template" element={<Outlet />}> 

--- a/src/api/services/quote.service.ts
+++ b/src/api/services/quote.service.ts
@@ -52,6 +52,8 @@ export const QuoteService = {
     type?: string;
     quoteName?: string;
     customerName?: string;
+    status?: string;
+    approvalNode?: string;
     sorters?: { field: string; order: string }[];
   }) {
     const { sorters, ...rest } = params || {};

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -63,6 +63,10 @@ const MainLayout: React.FC = () => {
       label: "OA报价单",
     },
     {
+      key: "/quote/todo",
+      label: "代办任务",
+    },
+    {
       key: "/template",
       label: "模版管理",
     },

--- a/src/components/general/SortableTable.tsx
+++ b/src/components/general/SortableTable.tsx
@@ -123,6 +123,7 @@ interface SortableTableProps<T extends { id: UniqueIdentifier; index?: number }>
   onDragEnd?: (data: T[]) => void;
   sortable?: boolean;
   rowKey?: keyof T; // 改为可选，默认使用 'id'
+  hiddenColumns?: string[];
 }
 
 export function SortableTable<
@@ -136,6 +137,7 @@ export function SortableTable<
   onDragEnd,
   sortable = true,
   rowKey = "id", // 默认使用 'id'
+  hiddenColumns = [],
   ...props
 }: SortableTableProps<T>) {
   const { columns = [], ...rest } = props;
@@ -153,6 +155,11 @@ export function SortableTable<
     );
   }, [columns]);
 
+  const visibleColumns = useMemo(
+    () => colState.filter((c) => !hiddenColumns.includes(String(c.key))),
+    [colState, hiddenColumns]
+  );
+
   const handleResizeColumn =
     (index: number) => (_: any, { size }: { size: { width: number } }) => {
       setColState((cols) => {
@@ -164,14 +171,14 @@ export function SortableTable<
 
   const mergedColumns = useMemo(
     () =>
-      colState.map((col, index) => ({
+      visibleColumns.map((col, index) => ({
         ...col,
         onHeaderCell: (column: any) => ({
           width: column.width,
           onResize: handleResizeColumn(index),
         }),
       })),
-    [colState]
+    [visibleColumns]
   );
   const handleDragEnd = ({ active, over }: DragEndEvent) => {
     if (!over || active.id === over.id) return;

--- a/src/components/quote/QuoteTable.tsx
+++ b/src/components/quote/QuoteTable.tsx
@@ -19,6 +19,8 @@ import { isTextSelecting } from "@/util/domUtil";
 
 interface QuoteTableProps {
   type: string; // 'history' | 'oa'
+  status?: string;
+  approvalNode?: string;
 }
 
 interface QuoteTableItem {
@@ -29,6 +31,8 @@ interface QuoteTableItem {
   quoteTime: Date;
   status: string;
   flowState: string;
+  currentApprovalNode: string;
+  currentApprover: string;
   chargerId: string;
   salesSupportId: string;
   quoteName: string;
@@ -37,7 +41,7 @@ interface QuoteTableItem {
   createdAt: string;
 }
 
-const QuoteTable: React.FC<QuoteTableProps> = ({ type }) => {
+const QuoteTable: React.FC<QuoteTableProps> = ({ type, status, approvalNode }) => {
   const { quotes, total, loading, fetchQuotes, fetchQuote } = useQuoteStore();
   const [modalVisible, setModalVisible] = useState(false);
   const [selectedQuote, setSelectedQuote] = useState<any>();
@@ -61,11 +65,21 @@ const QuoteTable: React.FC<QuoteTableProps> = ({ type }) => {
       type,
       quoteName: values.quoteName,
       customerName: values.customerName,
+      status,
+      approvalNode,
       sorters: sorters
         .filter((s) => s.order)
         .map((s) => ({ field: s.field as string, order: s.order as string })),
     });
-  }, [fetchQuotes, pagination.current, pagination.pageSize, sorters, type]);
+  }, [
+    fetchQuotes,
+    pagination.current,
+    pagination.pageSize,
+    sorters,
+    type,
+    status,
+    approvalNode,
+  ]);
 
   const handleSearch = () => {
     const values = searchForm.getFieldsValue();
@@ -76,6 +90,8 @@ const QuoteTable: React.FC<QuoteTableProps> = ({ type }) => {
       type,
       quoteName: values.quoteName,
       customerName: values.customerName,
+      status,
+      approvalNode,
       sorters: sorters
         .filter((s) => s.order)
         .map((s) => ({ field: s.field as string, order: s.order as string })),
@@ -97,6 +113,8 @@ const QuoteTable: React.FC<QuoteTableProps> = ({ type }) => {
       type,
       quoteName: values.quoteName,
       customerName: values.customerName,
+      status,
+      approvalNode,
       sorters: sorterArr
         .filter((s) => s.order)
         .map((s) => ({ field: s.field as string, order: s.order as string })),
@@ -174,6 +192,9 @@ const QuoteTable: React.FC<QuoteTableProps> = ({ type }) => {
           case "draft":
             color = "orange";
             break;
+          case "checking":
+            color = "blue";
+            break;
           case "completed":
             color = "green";
             break;
@@ -187,6 +208,8 @@ const QuoteTable: React.FC<QuoteTableProps> = ({ type }) => {
           <Tag color={color}>
             {status === "draft"
               ? "草稿"
+              : status === "checking"
+              ? "检查中"
               : status === "completed"
               ? "已完成"
               : "已锁定"}
@@ -207,6 +230,19 @@ const QuoteTable: React.FC<QuoteTableProps> = ({ type }) => {
                 {flowState || "未审批"}
               </Tag>
             ),
+          },
+          {
+            title: "当前节点",
+            dataIndex: "currentApprovalNode",
+            key: "currentApprovalNode",
+            width: 120,
+          },
+          {
+            title: "当前审批人",
+            dataIndex: "currentApprover",
+            key: "currentApprover",
+            width: 120,
+            render: (id: string) => (id && <MemberAvatar id={id} />) || "-",
           },
         ]),
     {
@@ -255,6 +291,8 @@ const QuoteTable: React.FC<QuoteTableProps> = ({ type }) => {
         createdAt: (quote as any).createdAt ?? "",
         status: quote.status,
         flowState: quote.flowState,
+        currentApprovalNode: quote.currentApprovalNode,
+        currentApprover: quote.currentApprover,
         chargerId: quote.chargerId,
         salesSupportId: quote.salesSupportId,
         quoteName: quote.quoteName,

--- a/src/page/quote/TodoQuoteTablePage.tsx
+++ b/src/page/quote/TodoQuoteTablePage.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Typography } from "antd";
+import QuoteTable from "@/components/quote/QuoteTable";
+
+const TodoQuoteTablePage: React.FC = () => {
+  return (
+    <>
+      <Typography.Title level={3}>代办任务</Typography.Title>
+      <QuoteTable type="history" status="checking" />
+      <QuoteTable type="oa" approvalNode="项目支持,报价单" />
+    </>
+  );
+};
+
+export default TodoQuoteTablePage;

--- a/src/store/useQuoteStore.ts
+++ b/src/store/useQuoteStore.ts
@@ -63,6 +63,8 @@ interface QuotesStore {
     type?: string;
     quoteName?: string;
     customerName?: string;
+    status?: string;
+    approvalNode?: string;
     sorters?: { field: string; order: string }[];
   }) => Promise<void>;
   fetchQuote: (quoteId: number) => Promise<Quote>;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -84,7 +84,7 @@ export interface Quote {
   contractPdf?: string; // 合同打印链接
   configPdf?: string; // 配置表打印链接
   items: QuoteItem[];
-  status: "draft" | "completed" | "locked";
+  status: "draft" | "checking" | "completed" | "locked";
 }
 
 export interface QuoteItem {


### PR DESCRIPTION
## Summary
- support hiding columns in `SortableTable` via new `hiddenColumns` prop
- show `currentApprovalNode` and `currentApprover` columns in OA quote table
- include the new fields when building `QuoteTable` row data
- allow querying quotes by status or approval node
- list pending tasks in `TodoQuoteTablePage`

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684e9f73aef483278717a2f12542c94b