### PR TITLE
Hide voltage fields for oil heating

### DIFF
--- a/src/components/quoteForm/FeedblockForm/FeedblockForm.tsx
+++ b/src/components/quoteForm/FeedblockForm/FeedblockForm.tsx
@@ -303,15 +303,21 @@ const FeedblockForm = forwardRef(
                 <HeatingMethodSelect multiple />
               </Form.Item>
             </Col>
-            <Col xs={24} md={12}>
-              <Form.Item
-                name="power"
-                label="电压"
-                rules={[{ required: true, message: "请输入电压" }]}
-              >
-                <PowerInput />
-              </Form.Item>
-            </Col>
+            <Form.Item noStyle dependencies={["heatingMethod"]}>
+              {({ getFieldValue }) =>
+                !getFieldValue("heatingMethod")?.includes("油加温") ? (
+                  <Col xs={24} md={12}>
+                    <Form.Item
+                      name="power"
+                      label="电压"
+                      rules={[{ required: true, message: "请输入电压" }]}
+                    >
+                      <PowerInput />
+                    </Form.Item>
+                  </Col>
+                ) : null
+              }
+            </Form.Item>
             <Col xs={12} md={6}>
               <Form.Item
                 name="heatingPower"

--- a/src/components/quoteForm/FilterForm/FilterForm.tsx
+++ b/src/components/quoteForm/FilterForm/FilterForm.tsx
@@ -152,15 +152,21 @@ const FilterForm = forwardRef(
                 unit="℃"
               />
             </Col>
-            <Col xs={24} md={12}>
-              <Form.Item
-                label="电压"
-                name="voltage"
-                rules={[{ required: true, message: "请选择电压" }]}
-              >
-                <PowerInput />
-              </Form.Item>
-            </Col>
+            <Form.Item noStyle dependencies={["heatingMethod"]}>
+              {({ getFieldValue }) =>
+                !getFieldValue("heatingMethod")?.includes("油加温") ? (
+                  <Col xs={24} md={12}>
+                    <Form.Item
+                      label="电压"
+                      name="voltage"
+                      rules={[{ required: true, message: "请选择电压" }]}
+                    >
+                      <PowerInput />
+                    </Form.Item>
+                  </Col>
+                ) : null
+              }
+            </Form.Item>
             <Col xs={12} md={6}>
               <Form.Item label="过滤器功率" name="power">
                 <InputNumber

--- a/src/components/quoteForm/MeteringPumpForm/ModelOption.tsx
+++ b/src/components/quoteForm/MeteringPumpForm/ModelOption.tsx
@@ -186,15 +186,21 @@ export const ModelOption = () => {
                         />
                       </Form.Item>
                     </Col>
-                    <Col xs={24} md={12}>
-                      <Form.Item
-                        label="泵体加热电压"
-                        name="pumpHeatingVoltage"
-                        rules={[{ required: true, message: "请选择加热方式" }]}
-                      >
-                        <PowerInput />
-                      </Form.Item>
-                    </Col>
+                    <Form.Item noStyle dependencies={["pumpHeatingType"]}>
+                      {({ getFieldValue }) =>
+                        !getFieldValue("pumpHeatingType")?.includes("油加温") ? (
+                          <Col xs={24} md={12}>
+                            <Form.Item
+                              label="泵体加热电压"
+                              name="pumpHeatingVoltage"
+                              rules={[{ required: true, message: "请选择加热方式" }]}
+                            >
+                              <PowerInput />
+                            </Form.Item>
+                          </Col>
+                        ) : null
+                      }
+                    </Form.Item>
                     <Col xs={12} md={12}>
                       <Form.Item
                         label="紧固件（螺丝）"

--- a/src/components/quoteForm/dieForm/TemperatureControl.tsx
+++ b/src/components/quoteForm/dieForm/TemperatureControl.tsx
@@ -74,11 +74,21 @@ export const TemperatureControl = () => {
             ) : null;
           }}
         </Form.Item>
-        <Col xs={24} sm={12}>
-          <Form.Item name="powerInput" label="加热电压" rules={powerInputRules}>
-            <PowerInput />
-          </Form.Item>
-        </Col>
+        <Form.Item noStyle dependencies={["heatingMethod"]}>
+          {({ getFieldValue }) =>
+            !getFieldValue("heatingMethod")?.includes("油加温") ? (
+              <Col xs={24} sm={12}>
+                <Form.Item
+                  name="powerInput"
+                  label="加热电压"
+                  rules={powerInputRules}
+                >
+                  <PowerInput />
+                </Form.Item>
+              </Col>
+            ) : null
+          }
+        </Form.Item>
         <Col xs={12} sm={12}>
           <Form.Item
             name="每区电压"


### PR DESCRIPTION
## Summary
- hide `powerInput` when oil heating is chosen in `TemperatureControl`
- hide `电压` field in `FeedblockForm` when oil heating is selected
- hide `voltage` field in `FilterForm` when oil heating is selected
- hide `pumpHeatingVoltage` in `ModelOption` when pump heating type is oil

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: network access to registry.npmmirror.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6852230f6c708327a42563a90f77070a