### PR TITLE
Adjust composite ratio list count based on layer number

### DIFF
--- a/src/components/quoteForm/dieForm/DieForm.tsx
+++ b/src/components/quoteForm/dieForm/DieForm.tsx
@@ -85,7 +85,21 @@ const DieForm = forwardRef(
       const ratioList = (form.getFieldValue("compositeRatio") ||
         []) as LevelValue[];
       const base = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-      const len = value.length;
+      const len = form.getFieldValue("runnerNumber") || value.length;
+      const ratioNext = Array.from({ length: len }, (_, i) => ({
+        level: base[i],
+      }));
+      form.setFieldValue(
+        "compositeRatio",
+        ratioList.slice(0, len).concat(ratioNext.slice(ratioList.length))
+      );
+    };
+
+    const handleRunnerNumber = (value: number) => {
+      const ratioList = (form.getFieldValue("compositeRatio") ||
+        []) as LevelValue[];
+      const base = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+      const len = value;
       const ratioNext = Array.from({ length: len }, (_, i) => ({
         level: base[i],
       }));
@@ -158,6 +172,7 @@ const DieForm = forwardRef(
         dieWidth: handleDieWidth,
         heatingZones: handleHeatingZones,
         compositeStructure: handleCompositeStructure,
+        runnerNumber: handleRunnerNumber,
         hasCart: handleHasCart,
         smartRegulator: handleSmartRegulator,
         haveThermalInsulation: handleThermalInsulation,

--- a/src/components/quoteForm/dieForm/Product.tsx
+++ b/src/components/quoteForm/dieForm/Product.tsx
@@ -203,8 +203,8 @@ export const Product = () => {
                     </Form.Item>
                   </Col>
                   <Col xs={24} md={24}>
-                    <ProFormDependency name={["compositeStructure"]}>
-                      {({ compositeStructure }) => (
+                    <ProFormDependency name={["compositeStructure", "runnerNumber"]}>
+                      {({ compositeStructure, runnerNumber }) => (
                         <ProFormListWrapper
                           name="compositeRatio"
                           label="每层复合比例"


### PR DESCRIPTION
## Summary
- update composite ratio list to use runner number length
- update dependency to re-render when layer count changes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685231775a5483279aeba70bd468f5a9