### PR TITLE
Hide voltage fields for oil heating

### DIFF
--- a/src/components/quoteForm/FeedblockForm/FeedblockForm.tsx
+++ b/src/components/quoteForm/FeedblockForm/FeedblockForm.tsx
@@ -27,6 +27,7 @@ import LevelInputNumber, {
 } from "@/components/general/LevelInputNumber";
 import ExtruderForm from "../formComponents/ExtruderForm";
 import { PowerInput } from "../formComponents/PowerInput";
+import PowerFormItem from "../formComponents/PowerFormItem";
 import { HeatingMethodSelect } from "../formComponents/HeatingMethodInput";
 import ProFormListWrapper from "../formComponents/ProFormListWrapper";
 import { CustomSelect } from "@/components/general/CustomSelect";
@@ -303,15 +304,12 @@ const FeedblockForm = forwardRef(
                 <HeatingMethodSelect multiple />
               </Form.Item>
             </Col>
-            <Col xs={24} md={12}>
-              <Form.Item
-                name="power"
-                label="电压"
-                rules={[{ required: true, message: "请输入电压" }]}
-              >
-                <PowerInput />
-              </Form.Item>
-            </Col>
+            <PowerFormItem
+              dependencyName="heatingMethod"
+              name="power"
+              label="电压"
+              rules={[{ required: true, message: "请输入电压" }]}
+            />
             <Col xs={12} md={6}>
               <Form.Item
                 name="heatingPower"

--- a/src/components/quoteForm/FilterForm/FilterForm.tsx
+++ b/src/components/quoteForm/FilterForm/FilterForm.tsx
@@ -4,6 +4,7 @@ import ProForm from "@ant-design/pro-form";
 import { forwardRef, useEffect, useImperativeHandle } from "react";
 
 import { PowerInput } from "../formComponents/PowerInput";
+import PowerFormItem from "../formComponents/PowerFormItem";
 import { HeatingMethodSelect } from "../formComponents/HeatingMethodInput";
 import { useProductStore } from "@/store/useProductStore";
 import { useQuoteStore } from "@/store/useQuoteStore";
@@ -152,15 +153,12 @@ const FilterForm = forwardRef(
                 unit="℃"
               />
             </Col>
-            <Col xs={24} md={12}>
-              <Form.Item
-                label="电压"
-                name="voltage"
-                rules={[{ required: true, message: "请选择电压" }]}
-              >
-                <PowerInput />
-              </Form.Item>
-            </Col>
+            <PowerFormItem
+              dependencyName="heatingMethod"
+              name="voltage"
+              label="电压"
+              rules={[{ required: true, message: "请选择电压" }]}
+            />
             <Col xs={12} md={6}>
               <Form.Item label="过滤器功率" name="power">
                 <InputNumber

--- a/src/components/quoteForm/MeteringPumpForm/ModelOption.tsx
+++ b/src/components/quoteForm/MeteringPumpForm/ModelOption.tsx
@@ -20,6 +20,7 @@ import { useProductStore } from "@/store/useProductStore";
 import ExtruderForm from "../formComponents/ExtruderForm";
 import { HeatingMethodSelect } from "../formComponents/HeatingMethodInput";
 import { PowerInput } from "../formComponents/PowerInput";
+import PowerFormItem from "../formComponents/PowerFormItem";
 import { inputRule } from "@/util/rules";
 
 const tagsData = ["泵体", "传动系统", "控制系统"];
@@ -186,15 +187,12 @@ export const ModelOption = () => {
                         />
                       </Form.Item>
                     </Col>
-                    <Col xs={24} md={12}>
-                      <Form.Item
-                        label="泵体加热电压"
-                        name="pumpHeatingVoltage"
-                        rules={[{ required: true, message: "请选择加热方式" }]}
-                      >
-                        <PowerInput />
-                      </Form.Item>
-                    </Col>
+                    <PowerFormItem
+                      dependencyName="pumpHeatingType"
+                      name="pumpHeatingVoltage"
+                      label="泵体加热电压"
+                      rules={[{ required: true, message: "请选择加热方式" }]}
+                    />
                     <Col xs={12} md={12}>
                       <Form.Item
                         label="紧固件（螺丝）"

--- a/src/components/quoteForm/dieForm/TemperatureControl.tsx
+++ b/src/components/quoteForm/dieForm/TemperatureControl.tsx
@@ -11,6 +11,7 @@ import {
 } from "antd";
 import { powerInputRules } from "@/util/rules";
 import { PowerInput } from "../formComponents/PowerInput";
+import PowerFormItem from "../formComponents/PowerFormItem";
 import { HeatingMethodSelect } from "../formComponents/HeatingMethodInput";
 import { useState } from "react";
 import { TooltipLabel } from "@/components/general/TooltipLabel";
@@ -74,11 +75,13 @@ export const TemperatureControl = () => {
             ) : null;
           }}
         </Form.Item>
-        <Col xs={24} sm={12}>
-          <Form.Item name="powerInput" label="加热电压" rules={powerInputRules}>
-            <PowerInput />
-          </Form.Item>
-        </Col>
+        <PowerFormItem
+          dependencyName="heatingMethod"
+          name="powerInput"
+          label="加热电压"
+          rules={powerInputRules}
+          colProps={{ xs: 24, sm: 12 }}
+        />
         <Col xs={12} sm={12}>
           <Form.Item
             name="每区电压"

--- a/src/components/quoteForm/formComponents/PowerFormItem.tsx
+++ b/src/components/quoteForm/formComponents/PowerFormItem.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Col, Form } from 'antd';
+import type { ColProps } from 'antd';
+import type { FormItemProps } from 'antd';
+import { PowerInput } from './PowerInput';
+
+interface PowerFormItemProps extends FormItemProps {
+  /** Field name that controls heating method */
+  dependencyName: string;
+  /** Column layout for the inner item */
+  colProps?: ColProps;
+}
+
+/**
+ * Display power input when heating method includes "加热棒" or "加热板".
+ */
+export const PowerFormItem: React.FC<PowerFormItemProps> = ({
+  dependencyName,
+  colProps = { xs: 24, md: 12 },
+  ...itemProps
+}) => {
+  return (
+    <Form.Item noStyle dependencies={[dependencyName]}>
+      {({ getFieldValue }) => {
+        const methods = getFieldValue(dependencyName);
+        const showVoltage = Array.isArray(methods)
+          ? methods.some((m: string) => m === '加热棒' || String(m).includes('加热板'))
+          : methods && (methods === '加热棒' || String(methods).includes('加热板'));
+
+        return showVoltage ? (
+          <Col {...colProps}>
+            <Form.Item {...itemProps}>
+              <PowerInput />
+            </Form.Item>
+          </Col>
+        ) : null;
+      }}
+    </Form.Item>
+  );
+};
+
+export default PowerFormItem;


### PR DESCRIPTION
## Summary
- hide `powerInput` when oil heating is chosen in `TemperatureControl`
- hide `电压` field in `FeedblockForm` when oil heating is selected
- hide `voltage` field in `FilterForm` when oil heating is selected
- hide `pumpHeatingVoltage` in `ModelOption` when pump heating type is oil
- refactor by introducing `PowerFormItem` component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: network access to registry.npmmirror.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6852230f6c708327a42563a90f77070a