### PR TITLE
Add lip count and thickness field handler

### DIFF
--- a/src/components/quoteForm/dieForm/DieBody.tsx
+++ b/src/components/quoteForm/dieForm/DieBody.tsx
@@ -1,8 +1,10 @@
-import { ProCard } from "@ant-design/pro-components";
-import { Badge, Col, Form, Radio, Row } from "antd";
+import { ProCard, ProFormDependency } from "@ant-design/pro-components";
+import { Badge, Col, Form, Radio, Row, InputNumber } from "antd";
 import { MATERIAL_OPTIONS } from "@/util/MATERIAL";
 import { CustomSelect } from "@/components/general/CustomSelect";
 import { AutoCompleteInput } from "@/components/general/AutoCompleteInput";
+import { IntervalInputFormItem } from "@/components/general/IntervalInput";
+import ProFormListWrapper from "../formComponents/ProFormListWrapper";
 
 // 常量定义
 const UPPER_LIP_OPTIONS = {
@@ -104,6 +106,40 @@ export const DieBody = () => {
           >
             <CustomSelect initialGroups={LOWER_LIP_OPTIONS} dropdown={false} />
           </Form.Item>
+        </Col>
+        <Col xs={12} md={6}>
+          <Form.Item
+            name="lipCount"
+            label="模唇数量"
+            rules={[{ required: true, message: "请输入模唇数量" }]}
+            initialValue={1}
+          >
+            <InputNumber min={1} style={{ width: "100%" }} />
+          </Form.Item>
+        </Col>
+        <Col xs={24} md={24}>
+          <ProFormDependency name={["lipCount"]}>
+            {({ lipCount }) =>
+              lipCount > 1 ? (
+                <ProFormListWrapper
+                  name="lipThicknessRange"
+                  label="模唇厚度范围"
+                  canCreate={false}
+                  canDelete={false}
+                  min={lipCount}
+                  max={lipCount}
+                  isHorizontal
+                  formItems={
+                    <IntervalInputFormItem
+                      name={[]}
+                      rules={[{ required: true, message: "请输入厚度范围" }]}
+                      unit="mm"
+                    />
+                  }
+                />
+              ) : null
+            }
+          </ProFormDependency>
         </Col>
         <Col xs={12} md={6}>
           {/* 4. 微调间距 */}

--- a/src/components/quoteForm/dieForm/DieForm.tsx
+++ b/src/components/quoteForm/dieForm/DieForm.tsx
@@ -167,6 +167,20 @@ const DieForm = forwardRef(
       if (!result.result) form.setFieldValue("thicknessGauge", true);
     };
 
+    const handleLipCount = (value: number) => {
+      const count = value ?? 1;
+      if (count <= 1) {
+        form.setFieldValue("lipThicknessRange", []);
+        return;
+      }
+      const list = (form.getFieldValue("lipThicknessRange") || []) as any[];
+      const next = Array.from({ length: count }, () => ({}));
+      form.setFieldValue(
+        "lipThicknessRange",
+        list.slice(0, count).concat(next.slice(list.length))
+      );
+    };
+
     const fieldHandlers: Record<string, (value: any) => void | Promise<void>> =
       {
         dieWidth: handleDieWidth,
@@ -177,6 +191,7 @@ const DieForm = forwardRef(
         smartRegulator: handleSmartRegulator,
         haveThermalInsulation: handleThermalInsulation,
         thicknessGauge: handleThicknessGauge,
+        lipCount: handleLipCount,
       };
 
     const handleFieldsChange = async (changedFields: any) => {


### PR DESCRIPTION
## Summary
- sync `lipThicknessRange` list with `lipCount` in DieForm

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: blocked by network policy)*

------
https://chatgpt.com/codex/tasks/task_e_68525c3cddc8832796d3f2e4f4f63c57