### PR TITLE
Add selectable unit support to interval input

### DIFF
--- a/src/components/general/IntervalInput.tsx
+++ b/src/components/general/IntervalInput.tsx
@@ -5,7 +5,7 @@ import React, {
   forwardRef,
   useImperativeHandle,
 } from "react";
-import { Form, Input } from "antd";
+import { Form, Input, Select } from "antd";
 import type { FormItemProps } from "antd";
 import { intervalInputRules } from "@/util/rules";
 import type { IntervalValue } from "@/types/types";
@@ -21,6 +21,8 @@ export interface IntervalInputProps {
   addonBefore?: string | null;
   /** Display unit inside the input */
   unit?: string;
+  /** available units to choose from */
+  units?: string[];
   disabled?: boolean;
   /** When true, user cannot modify the value but it remains selectable */
   readOnly?: boolean;
@@ -45,6 +47,7 @@ const IntervalInput: React.FC<IntervalInputProps> = forwardRef<
       addonAfter = null,
       addonBefore = null,
       unit,
+      units,
       extra = false,
       style,
       decimalPlace = 2,
@@ -52,6 +55,9 @@ const IntervalInput: React.FC<IntervalInputProps> = forwardRef<
     ref
   ) => {
     const [internalValue, setInternalValue] = useState(value?.value ?? "");
+    const [internalUnit, setInternalUnit] = useState(
+      value?.unit ?? unit ?? units?.[0] ?? ""
+    );
     const [isFocused, setIsFocused] = useState(false);
     const inputRef = useRef<any>(null);
     const lastCursorPos = useRef(0);
@@ -74,10 +80,13 @@ const IntervalInput: React.FC<IntervalInputProps> = forwardRef<
     // );
 
     useEffect(() => {
-      if (value?.value !== internalValue) {
+      if (value?.value !== undefined && value?.value !== internalValue) {
         setInternalValue(value?.value ?? "");
       }
-    }, [value?.value]);
+      if (value?.unit !== undefined && value?.unit !== internalUnit) {
+        setInternalUnit(value?.unit ?? "");
+      }
+    }, [value?.value, value?.unit]);
 
     const constructValue = (val: string): IntervalValue => {
       const [frontStr, rearStr] = val.split(DELIMITER);
@@ -85,13 +94,14 @@ const IntervalInput: React.FC<IntervalInputProps> = forwardRef<
         front: frontStr ? parseFloat(frontStr) : NaN,
         rear: rearStr ? parseFloat(rearStr) : NaN,
         value: val,
-        unit: unit ?? "",
+        unit: internalUnit ?? "",
       };
     };
 
-    const customOnChange = (newValue: string) => {
+    const customOnChange = (newValue: string, newUnit: string = internalUnit) => {
       try {
         const v = constructValue(newValue);
+        v.unit = newUnit;
         if (extra) {
           const e = { target: { value: v.value } };
           onChange?.(e as any);
@@ -108,8 +118,8 @@ const IntervalInput: React.FC<IntervalInputProps> = forwardRef<
       if (!isFocused && display.endsWith(DELIMITER)) {
         display = display.slice(0, -1);
       }
-      if (!isFocused && unit) {
-        display += unit;
+      if (!isFocused && (internalUnit || unit)) {
+        display += internalUnit || unit;
       }
       return display;
     };
@@ -232,6 +242,25 @@ const IntervalInput: React.FC<IntervalInputProps> = forwardRef<
       }
     };
 
+    const addonAfterNode = units && units.length ? (
+      <Select
+        size="small"
+        value={internalUnit}
+        onChange={(val) => {
+          setInternalUnit(val);
+          customOnChange(internalValue, val);
+        }}
+      >
+        {units.map((u) => (
+          <Select.Option key={u} value={u}>
+            {u}
+          </Select.Option>
+        ))}
+      </Select>
+    ) : (
+      addonAfter
+    );
+
     return (
       <Input
         id={id}
@@ -244,7 +273,7 @@ const IntervalInput: React.FC<IntervalInputProps> = forwardRef<
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
         disabled={disabled}
-        addonAfter={addonAfter}
+        addonAfter={addonAfterNode}
         readOnly={readOnly}
         style={style}
       />
@@ -260,6 +289,7 @@ interface NumberRangeInputFormItemProps extends FormItemProps {
   addonAfter?: string;
   isSecondNumberGreater?: boolean;
   unit?: string;
+  units?: string[];
   readOnly?: boolean;
 }
 
@@ -270,6 +300,7 @@ const IntervalInputFormItem: React.FC<NumberRangeInputFormItemProps> = ({
   addonAfter,
   isSecondNumberGreater = true,
   unit,
+  units,
   readOnly,
   ...formItemProps
 }) => {
@@ -288,6 +319,7 @@ const IntervalInputFormItem: React.FC<NumberRangeInputFormItemProps> = ({
         placeholder={placeholder}
         addonAfter={addonAfter}
         unit={unit}
+        units={units}
         readOnly={readOnly}
       />
     </ProForm.Item>

--- a/src/components/general/IntervalInput1.tsx
+++ b/src/components/general/IntervalInput1.tsx
@@ -5,7 +5,7 @@ import React, {
   forwardRef,
   useImperativeHandle,
 } from "react";
-import { Form, Input } from "antd";
+import { Form, Input, Select } from "antd";
 import type { FormItemProps } from "antd";
 import { intervalInputRules } from "@/util/rules";
 import type { IntervalValue } from "@/types/types";
@@ -20,6 +20,8 @@ export interface IntervalInputProps {
   addonBefore?: string | null;
   /** Display unit inside the input */
   unit?: string;
+  /** available units to choose from */
+  units?: string[];
   disabled?: boolean;
   /** When true, user cannot modify the value but it remains selectable */
   readOnly?: boolean;
@@ -44,6 +46,7 @@ const IntervalInput1: React.FC<IntervalInputProps> = forwardRef<
       addonAfter = null,
       addonBefore = null,
       unit,
+      units,
       extra = false,
       style,
       decimalPlace = 2,
@@ -51,6 +54,7 @@ const IntervalInput1: React.FC<IntervalInputProps> = forwardRef<
     ref
   ) => {
     const [internalValue, setInternalValue] = useState(value);
+    const [internalUnit, setInternalUnit] = useState(unit ?? units?.[0] ?? "");
     const [isFocused, setIsFocused] = useState(false);
     const inputRef = useRef<any>(null);
     const lastCursorPos = useRef(0);
@@ -74,15 +78,17 @@ const IntervalInput1: React.FC<IntervalInputProps> = forwardRef<
 
     useEffect(() => {
       setInternalValue(value);
-    }, [value]);
+      if (unit !== undefined) setInternalUnit(unit);
+    }, [value, unit]);
 
-    const customOnChange = (newValue: string) => {
+    const customOnChange = (newValue: string, newUnit: string = internalUnit) => {
       if (extra) {
         const e = { target: { value: newValue } };
         onChange?.(e as any);
       } else {
         onChange?.(newValue);
       }
+      setInternalUnit(newUnit);
     };
 
     const formatDisplayValue = (val: string) => {
@@ -90,8 +96,8 @@ const IntervalInput1: React.FC<IntervalInputProps> = forwardRef<
       if (!isFocused && display?.endsWith(DELIMITER)) {
         display = display.slice(0, -1);
       }
-      if (!isFocused && unit) {
-        display += unit;
+      if (!isFocused && (internalUnit || unit)) {
+        display += internalUnit || unit;
       }
       return display;
     };
@@ -213,6 +219,25 @@ const IntervalInput1: React.FC<IntervalInputProps> = forwardRef<
       }
     };
 
+    const addonAfterNode = units && units.length ? (
+      <Select
+        size="small"
+        value={internalUnit}
+        onChange={(val) => {
+          setInternalUnit(val);
+          customOnChange(internalValue, val);
+        }}
+      >
+        {units.map((u) => (
+          <Select.Option key={u} value={u}>
+            {u}
+          </Select.Option>
+        ))}
+      </Select>
+    ) : (
+      addonAfter
+    );
+
     return (
       <Input
         id={id}
@@ -225,7 +250,7 @@ const IntervalInput1: React.FC<IntervalInputProps> = forwardRef<
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
         disabled={disabled}
-        addonAfter={addonAfter}
+        addonAfter={addonAfterNode}
         readOnly={readOnly}
         style={style}
       />
@@ -241,6 +266,7 @@ interface NumberRangeInputFormItemProps extends FormItemProps {
   addonAfter?: string;
   isSecondNumberGreater?: boolean;
   unit?: string;
+  units?: string[];
   readOnly?: boolean;
 }
 
@@ -251,6 +277,7 @@ const IntervalInputFormItem: React.FC<NumberRangeInputFormItemProps> = ({
   addonAfter,
   isSecondNumberGreater = true,
   unit,
+  units,
   readOnly,
   ...formItemProps
 }) => {
@@ -269,6 +296,7 @@ const IntervalInputFormItem: React.FC<NumberRangeInputFormItemProps> = ({
         placeholder={placeholder}
         addonAfter={addonAfter}
         unit={unit}
+        units={units}
         readOnly={readOnly}
       />
     </Form.Item>

--- a/src/components/general/LevelInputNumber.tsx
+++ b/src/components/general/LevelInputNumber.tsx
@@ -10,7 +10,7 @@ export interface LevelValue {
 export interface LevelInputNumberProps
   extends Omit<
     IntervalInputProps,
-    "value" | "onChange" | "addonBefore" | "unit"
+    "value" | "onChange" | "addonBefore" | "unit" | "units"
   > {
   value?: LevelValue;
   onChange?: (val: LevelValue) => void;


### PR DESCRIPTION
## Summary
- add `units` prop to `IntervalInput` and `IntervalInput1`
- render unit selector in `addonAfter`
- allow form item wrappers to pass `units`
- omit `units` from `LevelInputNumber` props

## Testing
- `npm run build` *(fails: Cannot find type definition file for '@eslint/js', etc.)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68540a7686388327ac5ec5e7c1c2c2b4