### PR TITLE
Add approver filter and submit flow action

### DIFF
--- a/src/api/services/quote.service.ts
+++ b/src/api/services/quote.service.ts
@@ -40,9 +40,10 @@ export const QuoteService = {
     });
     return quote.data;
   },
-  async updateQuoteItem(quote: Quote) {
+  async updateQuoteItem(quote: Quote, submit = false) {
     const result = await apiClient.post("/quote/update", {
       quote,
+      submit,
     });
     return result.data;
   },
@@ -54,6 +55,7 @@ export const QuoteService = {
     customerName?: string;
     status?: string;
     approvalNode?: string;
+    currentApprover?: string;
     sorters?: { field: string; order: string }[];
   }) {
     const { sorters, ...rest } = params || {};

--- a/src/components/quote/QuoteForm.tsx
+++ b/src/components/quote/QuoteForm.tsx
@@ -152,6 +152,7 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
     useQuoteStore();
   const [saveLoading, setSaveLoading] = useState(false);
   const [submitLoading, setSubmitLoading] = useState(false);
+  const [submitFlowLoading, setSubmitFlowLoading] = useState(false);
   const [contacts, setContacts] = useState<any[]>([]);
   const [nameOptions, setNameOptions] = useState<
     { value: string; label: string }[]
@@ -284,6 +285,21 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
     { leading: true, trailing: false }
   );
 
+  const submitFlow = throttle(
+    async () => {
+      setSubmitFlowLoading(true);
+      if (!quote?.id) {
+        message.error("提交失败");
+        return;
+      }
+      await saveQuote(quote.id, true);
+      setSubmitFlowLoading(false);
+      message.success("已提交流程");
+    },
+    5000,
+    { leading: true, trailing: false }
+  );
+
   const updateStore = debounce((changedValues: any) => {
     if (!quote?.id) return;
 
@@ -309,6 +325,7 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
     userId === quote?.projectManagerId || userId === quote?.chargerId;
   const submitLabel =
     quote?.status === "checking" && isManager ? "已检查" : "提交";
+  const showSubmitFlow = quote?.currentApprover === userId;
 
   return (
     <Form
@@ -394,6 +411,15 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
           >
             {submitLabel}
           </Button>
+          {showSubmitFlow && (
+            <Button
+              style={{ marginLeft: 8 }}
+              onClick={submitFlow}
+              loading={loading && submitFlowLoading}
+            >
+              提交流程
+            </Button>
+          )}
           <Button
             style={{ marginLeft: 8 }}
             onClick={save}

--- a/src/components/quote/QuoteTable.tsx
+++ b/src/components/quote/QuoteTable.tsx
@@ -18,6 +18,7 @@ interface QuoteTableProps {
   type: string; // 'history' | 'oa'
   status?: string;
   approvalNode?: string;
+  currentApprover?: string;
 }
 
 interface QuoteTableItem {
@@ -42,6 +43,7 @@ const QuoteTable: React.FC<QuoteTableProps> = ({
   type,
   status,
   approvalNode,
+  currentApprover,
 }) => {
   const { quotes, total, loading, fetchQuotes, fetchQuote } = useQuoteStore();
   const [modalVisible, setModalVisible] = useState(false);
@@ -68,6 +70,7 @@ const QuoteTable: React.FC<QuoteTableProps> = ({
       customerName: values.customerName,
       status,
       approvalNode,
+      currentApprover,
       sorters: sorters
         .filter((s) => s.order)
         .map((s) => ({ field: s.field as string, order: s.order as string })),
@@ -80,6 +83,7 @@ const QuoteTable: React.FC<QuoteTableProps> = ({
     type,
     status,
     approvalNode,
+    currentApprover,
   ]);
 
   const handleSearch = () => {
@@ -93,6 +97,7 @@ const QuoteTable: React.FC<QuoteTableProps> = ({
       customerName: values.customerName,
       status,
       approvalNode,
+      currentApprover,
       sorters: sorters
         .filter((s) => s.order)
         .map((s) => ({ field: s.field as string, order: s.order as string })),
@@ -116,6 +121,7 @@ const QuoteTable: React.FC<QuoteTableProps> = ({
       customerName: values.customerName,
       status,
       approvalNode,
+      currentApprover,
       sorters: sorterArr
         .filter((s) => s.order)
         .map((s) => ({ field: s.field as string, order: s.order as string })),

--- a/src/page/quote/TodoQuoteTablePage.tsx
+++ b/src/page/quote/TodoQuoteTablePage.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { Typography } from "antd";
 import QuoteTable from "@/components/quote/QuoteTable";
+import { useAuthStore } from "@/store/useAuthStore";
 
 const TodoQuoteTablePage: React.FC = () => {
+  const userId = useAuthStore.getState().userid?.id;
   return (
     <>
       <Typography.Title level={3}>代办任务</Typography.Title>
-      <QuoteTable type="history" status="checking" />
+      <QuoteTable type="history" currentApprover={userId} />
       {/* <QuoteTable type="oa" approvalNode="项目支持,报价单" /> */}
     </>
   );

--- a/src/store/useQuoteStore.ts
+++ b/src/store/useQuoteStore.ts
@@ -65,6 +65,7 @@ interface QuotesStore {
     customerName?: string;
     status?: string;
     approvalNode?: string;
+    currentApprover?: string;
     sorters?: { field: string; order: string }[];
   }) => Promise<void>;
   fetchQuote: (quoteId: number) => Promise<Quote>;
@@ -100,7 +101,7 @@ interface QuotesStore {
     updateConfig: any
   ) => void;
   setQuoteItem: (quoteId: number, items: QuoteItem[]) => void;
-  saveQuote: (quoteId: number) => Promise<void>;
+  saveQuote: (quoteId: number, submit?: boolean) => Promise<void>;
   fetchPrintUrls: (quoteId: number) => Promise<void>;
   findItemById: (
     items: QuoteItem[],
@@ -395,11 +396,11 @@ export const useQuoteStore = create<QuotesStore>()(
       return undefined;
     },
 
-    saveQuote: async (quoteId) => {
+    saveQuote: async (quoteId, submit = false) => {
       set({ loading: { ...get().loading, saveQuote: true } });
       const quote = get().quotes.find((quote) => quoteId == quote.id);
       if (quote) {
-        await QuoteService.updateQuoteItem(quote);
+        await QuoteService.updateQuoteItem(quote, submit);
         set((state) => {
           state.dirtyQuotes[quoteId] = false;
         });


### PR DESCRIPTION
## Summary
- filter todo quote list by current approver only
- show **Submit Flow** button when current user is the approver
- include `submit` flag in quote update API

## Testing
- `npm run lint` *(fails: cannot find module)*
- `npm install` *(fails: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685431bdb3848327aebedd292bf77c50