### PR TITLE
Add quote deal status

### DIFF
--- a/src/components/quote/DesktopQuoteItemsTable.tsx
+++ b/src/components/quote/DesktopQuoteItemsTable.tsx
@@ -48,6 +48,9 @@ const DesktopQuoteItemsTable: React.FC<QuoteItemsTableProps> = ({
       state.quotes.find((quote) => quote.id === quoteId)?.status == "locked" ||
       false
   );
+  const isClosed = useQuoteStore(
+    (state) => state.quotes.find((quote) => quote.id === quoteId)?.isClosed
+  );
   const { addQuoteItem, updateQuoteItem, setQuoteItem } = useQuoteStore();
   const { message } = App.useApp();
   const loading = useQuoteStore((state) => state.loading);
@@ -381,6 +384,7 @@ const DesktopQuoteItemsTable: React.FC<QuoteItemsTableProps> = ({
         setOpen={setOpen}
         quoteId={quoteId}
         quoteItem={currentItem ?? items[0]}
+        isClosed={isClosed}
       />
     </>
   );

--- a/src/components/quote/ProductConfigForm/ProductConfigModal.tsx
+++ b/src/components/quote/ProductConfigForm/ProductConfigModal.tsx
@@ -12,6 +12,7 @@ interface ProductConfigModalProps {
   setOpen: (bool: boolean) => void;
   quoteId: number;
   quoteItem: QuoteItem | undefined;
+  isClosed?: boolean;
 }
 
 const ProductConfigModal: React.FC<ProductConfigModalProps> = ({
@@ -19,6 +20,7 @@ const ProductConfigModal: React.FC<ProductConfigModalProps> = ({
   setOpen,
   quoteId,
   quoteItem,
+  isClosed = false,
 }) => {
   const onUpdateItem = useQuoteStore((state) => state.updateQuoteItem);
   const material = useQuoteStore(
@@ -189,6 +191,7 @@ const ProductConfigModal: React.FC<ProductConfigModalProps> = ({
           style={{ display: loading ? "none" : "block" }}
           material={material}
           finalProduct={finalProduct}
+          isClosed={isClosed}
         />
         <ImportProductModal
           open={importOpen}

--- a/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
+++ b/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
@@ -23,6 +23,7 @@ interface ProductConfigurationFormProps {
   readOnly?: boolean;
   formType?: string;
   quoteTemplate?: QuoteTemplate;
+  isClosed?: boolean;
 }
 const ProductConfigurationForm = forwardRef(
   (
@@ -36,6 +37,7 @@ const ProductConfigurationForm = forwardRef(
       readOnly = false,
       formType: formTypeProp,
       quoteTemplate,
+      isClosed = false,
     }: ProductConfigurationFormProps,
     ref
   ) => {
@@ -157,6 +159,8 @@ const ProductConfigurationForm = forwardRef(
                     ref={priceFormRef}
                     onGenerateName={generateName}
                     readOnly={readOnly}
+                    showProductCode={isClosed}
+                    requiredProductCode={isClosed}
                   />
                 ),
                 forceRender: true,

--- a/src/components/quote/QuoteConfigTab.tsx
+++ b/src/components/quote/QuoteConfigTab.tsx
@@ -7,6 +7,7 @@ import {
   InputNumber,
   AutoComplete,
   DatePicker,
+  Switch,
 } from "antd";
 import { ProCard } from "@ant-design/pro-components";
 import dayjs from "dayjs";
@@ -356,6 +357,11 @@ const QuoteConfigTab: React.FC<QuoteConfigTabProps> = ({
                 onChange={onDateChange}
                 maxDate={dayjs("2025/5/1")}
               />
+            </Form.Item>
+          </Col>
+          <Col xs={12} md={6}>
+            <Form.Item name="isClosed" label="是否已成交" valuePropName="checked">
+              <Switch />
             </Form.Item>
           </Col>
         </Row>

--- a/src/components/quoteForm/PriceForm.tsx
+++ b/src/components/quoteForm/PriceForm.tsx
@@ -18,6 +18,8 @@ interface PriceFormRef {
 interface PriceFormProps {
   onGenerateName?: () => string | undefined;
   readOnly?: boolean;
+  showProductCode?: boolean;
+  requiredProductCode?: boolean;
 }
 
 const brandOption = [
@@ -27,7 +29,10 @@ const brandOption = [
 ];
 
 const PriceForm = forwardRef<PriceFormRef, PriceFormProps>(
-  ({ onGenerateName, readOnly = false }, ref) => {
+  (
+    { onGenerateName, readOnly = false, showProductCode = false, requiredProductCode = false },
+    ref
+  ) => {
     const [form] = Form.useForm();
     // 暴露form实例给父组件
     useImperativeHandle(ref, () => ({
@@ -79,11 +84,21 @@ const PriceForm = forwardRef<PriceFormRef, PriceFormProps>(
             </Form.Item>
           </Col>
 
-          <Col xs={12} sm={12}>
-            <Form.Item name="productCode" label="产品编码">
-              <Input style={{ width: "100%" }} />
-            </Form.Item>
-          </Col>
+          {showProductCode && (
+            <Col xs={12} sm={12}>
+              <Form.Item
+                name="productCode"
+                label="产品编码"
+                rules={
+                  requiredProductCode
+                    ? [{ required: true, message: "请输入产品编码" }]
+                    : []
+                }
+              >
+                <Input style={{ width: "100%" }} />
+              </Form.Item>
+            </Col>
+          )}
 
           <Col xs={12} sm={12}>
             <Form.Item

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -83,6 +83,7 @@ export interface Quote {
   quotationPdf?: string; // 报价单打印链接
   contractPdf?: string; // 合同打印链接
   configPdf?: string; // 配置表打印链接
+  isClosed?: boolean; // 是否已成交
   items: QuoteItem[];
   status: "draft" | "checking" | "completed" | "locked";
 }


### PR DESCRIPTION
## Summary
- add `isClosed` flag to quote types and forms
- show deal switch on quote config tab
- require product code when quote is closed

## Testing
- `npx tsc -p tsconfig.json`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685447ecff4c8327bb67d6f363032978