### PR TITLE
Enable text wrapping in QuoteTable

### DIFF
--- a/src/components/quote/QuoteTable.less
+++ b/src/components/quote/QuoteTable.less
@@ -1,0 +1,6 @@
+.quoteTableWrap {
+  .ant-table-cell {
+    white-space: normal !important;
+    word-break: break-word;
+  }
+}

--- a/src/components/quote/QuoteTable.tsx
+++ b/src/components/quote/QuoteTable.tsx
@@ -13,6 +13,7 @@ import QuoteModal from "./QuoteModal";
 import { useQuoteStore } from "@/store/useQuoteStore";
 import { isTextSelecting } from "@/util/domUtil";
 import { SorterResult } from "antd/es/table/interface";
+import "./QuoteTable.less";
 
 interface QuoteTableProps {
   type: string; // 'history' | 'oa'
@@ -165,7 +166,6 @@ const QuoteTable: React.FC<QuoteTableProps> = ({
       dataIndex: "quoteName",
       key: "quoteName",
       width: 200,
-      ellipsis: true,
     },
     {
       title: "客户名称",
@@ -331,6 +331,7 @@ const QuoteTable: React.FC<QuoteTableProps> = ({
         </Form.Item>
       </Form>
       <Table<QuoteTableItem>
+        className="quoteTableWrap"
         columns={columns}
         dataSource={tableData}
         bordered


### PR DESCRIPTION
## Summary
- add QuoteTable style file for wrapping text
- remove ellipsis from QuoteTable column and apply styling class

## Testing
- `npm run lint` *(fails: registry.npmmirror.com not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68559100d4e0832790222e8b2f2aa813