### PR TITLE
Implement API-driven autocomplete for parts

### DIFF
--- a/src/api/services/part.service.ts
+++ b/src/api/services/part.service.ts
@@ -1,0 +1,11 @@
+import { apiClient } from "../http/client";
+import { PartSearchResult } from "@/types/types";
+
+export const PartService = {
+  async searchParts(keyword: string) {
+    const res = await apiClient.get("/product/part/search", {
+      params: { keyword },
+    });
+    return res.data as PartSearchResult[];
+  },
+};

--- a/src/components/quoteForm/PartsForm.tsx
+++ b/src/components/quoteForm/PartsForm.tsx
@@ -9,7 +9,11 @@ import {
   Typography,
 } from "antd";
 import ProForm, { ProFormList, ProFormDependency } from "@ant-design/pro-form";
-import { forwardRef, useImperativeHandle } from "react";
+import { forwardRef, useImperativeHandle, useEffect, useState } from "react";
+import { useDebounce } from "use-debounce";
+import { DefaultOptionType } from "antd/es/select";
+import { PartService } from "@/api/services/part.service";
+import { PartSearchResult } from "@/types/types";
 import { formatPrice } from "@/util/valueUtil";
 
 interface PartFormRef {
@@ -23,6 +27,61 @@ interface PartFormProps {
 const PartForm = forwardRef<PartFormRef, PartFormProps>(
   ({ readOnly = false }, ref) => {
     const [form] = Form.useForm();
+
+    const PartAutoComplete: React.FC<{ index: number }> = ({ index }) => {
+      const [search, setSearch] = useState("");
+      const [debouncedSearch] = useDebounce(search, 300);
+      const [options, setOptions] = useState<DefaultOptionType[]>([]);
+
+      useEffect(() => {
+        if (!debouncedSearch) {
+          setOptions([]);
+          return;
+        }
+        let cancelled = false;
+        PartService.searchParts(debouncedSearch).then((data) => {
+          if (cancelled) return;
+          const groups: Record<string, DefaultOptionType> = {};
+          data.forEach((p) => {
+            if (!groups[p.category]) {
+              groups[p.category] = { label: p.category, options: [] } as any;
+            }
+            (groups[p.category].options as DefaultOptionType[]).push({
+              label: (
+                <div style={{ display: "flex", justifyContent: "space-between" }}>
+                  <span>{p.name}</span>
+                  <span>
+                    {`${formatPrice(p.price)} / ${p.unit}${
+                      p.type === "M" ? " 自制件" : ""
+                    }`}
+                  </span>
+                </div>
+              ),
+              value: p.name,
+              item: p,
+            });
+          });
+          setOptions(Object.values(groups));
+        });
+        return () => {
+          cancelled = true;
+        };
+      }, [debouncedSearch]);
+
+      return (
+        <AutoComplete
+          options={options}
+          onSearch={setSearch}
+          onSelect={(_, option) => {
+            const item = (option as any).item as PartSearchResult;
+            form.setFieldValue(["parts", index, "unitPrice"], item.price);
+            form.setFieldValue(["parts", index, "unit"], item.unit);
+          }}
+          style={{ width: "100%" }}
+          placeholder="物料名称"
+        />
+      );
+    };
 
     useImperativeHandle(ref, () => ({
       form,
@@ -64,11 +123,7 @@ const PartForm = forwardRef<PartFormRef, PartFormProps>(
                   rules={[{ required: true, message: "请输入物料名称" }]}
                   readonly={readOnly}
                 >
-                  <AutoComplete
-                    options={[]}
-                    style={{ width: "100%" }}
-                    placeholder="物料名称"
-                  />
+                  <PartAutoComplete index={index} />
                 </ProForm.Item>
               </Col>
               <Col xs={12} md={3}>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -123,6 +123,15 @@ export interface ProductSearchResult {
   orderDate: string;
 }
 
+export interface PartSearchResult {
+  id: string;
+  name: string;
+  category: string;
+  price: number;
+  unit: string;
+  type: "P" | "M";
+}
+
 interface ProductConfig {
   [key: string]: any;
 }


### PR DESCRIPTION
## Summary
- create `part.service` for API calls
- add `PartSearchResult` types
- enable searching parts with a debounced `AutoComplete` in `PartsForm`
- group search results by category

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing type definitions such as 'react')*


------
https://chatgpt.com/codex/tasks/task_e_6857b155eb7c8327b96f6acba50a593c