### PR TITLE
Add PDF preview modal

### DIFF
--- a/src/components/general/PdfPreview.tsx
+++ b/src/components/general/PdfPreview.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from "react";
+import { Modal, Button } from "antd";
+import { DownloadOutlined } from "@ant-design/icons";
+
+interface PdfPreviewProps {
+  open: boolean;
+  blob: Blob | null;
+  onClose: () => void;
+  fileName?: string;
+}
+
+const PdfPreview: React.FC<PdfPreviewProps> = ({
+  open,
+  blob,
+  onClose,
+  fileName = "file.pdf",
+}) => {
+  const [url, setUrl] = useState<string>();
+
+  useEffect(() => {
+    if (blob) {
+      const objectUrl = URL.createObjectURL(blob);
+      setUrl(objectUrl);
+      return () => {
+        URL.revokeObjectURL(objectUrl);
+      };
+    }
+  }, [blob]);
+
+  const handleDownload = () => {
+    if (!url) return;
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = fileName;
+    a.style.display = "none";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  };
+
+  return (
+    <Modal
+      open={open}
+      footer={null}
+      onCancel={onClose}
+      width="80%"
+      style={{ top: 20 }}
+      destroyOnHidden
+    >
+      <div style={{ position: "relative", height: "80vh" }}>
+        <Button
+          type="primary"
+          icon={<DownloadOutlined />}
+          onClick={handleDownload}
+          style={{ position: "absolute", top: 0, right: 0, zIndex: 1 }}
+        >
+          下载
+        </Button>
+        {url && (
+          <iframe
+            src={url}
+            title="PDF Preview"
+            style={{ width: "100%", height: "100%", border: "none" }}
+          />
+        )}
+      </div>
+    </Modal>
+  );
+};
+
+export default PdfPreview;

--- a/src/components/quote/QuoteForm.tsx
+++ b/src/components/quote/QuoteForm.tsx
@@ -11,6 +11,7 @@ import { CustomerService } from "@/api/services/customer.service";
 import { DownOutlined } from "@ant-design/icons";
 import { useAuthStore } from "@/store/useAuthStore";
 import { QuoteService } from "@/api/services/quote.service";
+import PdfPreview from "../general/PdfPreview";
 
 const getDefaultQuoteTerms = (days: number): Clause[] => [
   {
@@ -160,6 +161,9 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
   const [phoneOptions, setPhoneOptions] = useState<
     { value: string; label: string }[]
   >([]);
+  const [preview, setPreview] = useState<{ blob: Blob; type: string } | null>(
+    null
+  );
   const deliveryDays = Form.useWatch("deliveryDays", form);
   const quoteTerms: Clause[] = Form.useWatch("quoteTerms", form) || [];
   const contractTerms: Clause[] = Form.useWatch("contractTerms", form) || [];
@@ -262,11 +266,9 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
 
   const print = async (type: "config" | "quote" | "contract") => {
     if (!quote?.id) return;
-    // await saveQuote(quote.id);
     const apiType = type === "quote" ? "quotation" : type;
     const blob = await QuoteService.print(apiType as any, quote.id);
-    const url = window.URL.createObjectURL(blob);
-    window.open(url, "_blank");
+    setPreview({ blob, type });
   };
 
   const save = throttle(
@@ -327,6 +329,7 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
   const showSubmitFlow = quote?.currentApprover === userId;
 
   return (
+    <>
     <Form
       form={form}
       scrollToFirstError={{ behavior: "smooth", block: "nearest", focus: true }}
@@ -429,6 +432,13 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
         </Col>
       </Row>
     </Form>
+    <PdfPreview
+      open={!!preview}
+      blob={preview?.blob ?? null}
+      fileName={`${preview?.type ?? ""}.pdf`}
+      onClose={() => setPreview(null)}
+    />
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- add a `PdfPreview` component with built-in download button
- use the new component in `QuoteForm` so printing shows a preview before download

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685a17eb8228832786ec54420848fac4