### PR TITLE
Make PDF preview fullscreen

### DIFF
--- a/src/components/general/PdfPreview.tsx
+++ b/src/components/general/PdfPreview.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from "react";
+import { Modal } from "antd";
+
+interface PdfPreviewProps {
+  open: boolean;
+  blob: Blob | null;
+  onClose: () => void;
+  fileName?: string;
+}
+
+const PdfPreview: React.FC<PdfPreviewProps> = ({
+  open,
+  blob,
+  onClose,
+  fileName = "file.pdf",
+}) => {
+  const [url, setUrl] = useState<string>();
+
+  useEffect(() => {
+    if (blob) {
+      const objectUrl = URL.createObjectURL(blob);
+      setUrl(objectUrl);
+      return () => {
+        URL.revokeObjectURL(objectUrl);
+      };
+    }
+  }, [blob]);
+
+
+  return (
+    <Modal
+      open={open}
+      footer={null}
+      onCancel={onClose}
+      width="100%"
+      style={{ top: 0, padding: 0 }}
+      styles={{ body: { height: "100vh" } }}
+      destroyOnHidden
+    >
+      <div style={{ position: "relative", height: "100%" }}>
+        {url && (
+          <iframe
+            src={url}
+            title="PDF Preview"
+            style={{ width: "100%", height: "100%", border: "none" }}
+          />
+        )}
+      </div>
+    </Modal>
+  );
+};
+
+export default PdfPreview;

--- a/src/components/quote/QuoteForm.tsx
+++ b/src/components/quote/QuoteForm.tsx
@@ -1,6 +1,6 @@
 // components/quote/QuoteForm.tsx
 import React, { useState, useEffect, useRef } from "react";
-import { Form, Button, Tabs, App, Row, Col, Dropdown, MenuProps } from "antd";
+import { Form, Button, Tabs, App, Row, Col, Dropdown, MenuProps, Spin } from "antd";
 import { Quote, Clause } from "@/types/types";
 import QuoteConfigTab from "./QuoteConfigTab";
 import QuoteTermsTab from "./QuoteTermsTab";
@@ -11,6 +11,7 @@ import { CustomerService } from "@/api/services/customer.service";
 import { DownOutlined } from "@ant-design/icons";
 import { useAuthStore } from "@/store/useAuthStore";
 import { QuoteService } from "@/api/services/quote.service";
+import PdfPreview from "../general/PdfPreview";
 
 const getDefaultQuoteTerms = (days: number): Clause[] => [
   {
@@ -160,6 +161,10 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
   const [phoneOptions, setPhoneOptions] = useState<
     { value: string; label: string }[]
   >([]);
+  const [preview, setPreview] = useState<{ blob: Blob; type: string } | null>(
+    null
+  );
+  const [previewLoading, setPreviewLoading] = useState(false);
   const deliveryDays = Form.useWatch("deliveryDays", form);
   const quoteTerms: Clause[] = Form.useWatch("quoteTerms", form) || [];
   const contractTerms: Clause[] = Form.useWatch("contractTerms", form) || [];
@@ -262,11 +267,14 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
 
   const print = async (type: "config" | "quote" | "contract") => {
     if (!quote?.id) return;
-    // await saveQuote(quote.id);
-    const apiType = type === "quote" ? "quotation" : type;
-    const blob = await QuoteService.print(apiType as any, quote.id);
-    const url = window.URL.createObjectURL(blob);
-    window.open(url, "_blank");
+    setPreviewLoading(true);
+    try {
+      const apiType = type === "quote" ? "quotation" : type;
+      const blob = await QuoteService.print(apiType as any, quote.id);
+      setPreview({ blob, type });
+    } finally {
+      setPreviewLoading(false);
+    }
   };
 
   const save = throttle(
@@ -327,8 +335,14 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
   const showSubmitFlow = quote?.currentApprover === userId;
 
   return (
-    <Form
-      form={form}
+    <>
+      {previewLoading && (
+        <div className="full-page-spin">
+          <Spin tip="加载中..." size="large" />
+        </div>
+      )}
+      <Form
+        form={form}
       scrollToFirstError={{ behavior: "smooth", block: "nearest", focus: true }}
       layout="vertical"
       onFinish={onFinish}
@@ -429,6 +443,13 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
         </Col>
       </Row>
     </Form>
+    <PdfPreview
+      open={!!preview}
+      blob={preview?.blob ?? null}
+      fileName={`${preview?.type ?? ""}.pdf`}
+      onClose={() => setPreview(null)}
+    />
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- remove the download button from `PdfPreview`
- make `PdfPreview` modal show fullscreen
- show a full-page spinner while fetching the PDF

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685a17eb8228832786ec54420848fac4