### PR TITLE
Implement optional fields and pricing options

### DIFF
--- a/src/components/quote/QuoteConfigTab.tsx
+++ b/src/components/quote/QuoteConfigTab.tsx
@@ -244,6 +244,16 @@ const QuoteConfigTab: React.FC<QuoteConfigTabProps> = ({
             </Form.Item>
           </Col>
           <Col xs={12} md={6}>
+            <Form.Item
+              name="hideItemPrice"
+              label="隐藏分项价格"
+              valuePropName="checked"
+              initialValue={false}
+            >
+              <Switch />
+            </Form.Item>
+          </Col>
+          <Col xs={12} md={6}>
             <Form.Item label="报价单金额">
               <MoneyInput
                 quoteId={quote?.id ?? 0}

--- a/src/components/quoteForm/MeteringPumpForm/MeteringPumpForm.tsx
+++ b/src/components/quoteForm/MeteringPumpForm/MeteringPumpForm.tsx
@@ -32,6 +32,9 @@ const MeteringPumpForm = forwardRef(
     const quoteItems = useQuoteStore
       .getState()
       .quotes.find((quote) => quote.id === quoteId)?.items;
+    const quoteType = useQuoteStore(
+      (state) => state.quotes.find((q) => q.id === quoteId)?.type
+    );
     const { showProductActionModal } = useProductActionModal();
     const pump = useProductStore((state) => state.pump);
     const addProp: any = (
@@ -195,7 +198,7 @@ const MeteringPumpForm = forwardRef(
           onValuesChange={handleFieldsChange}
           disabled={readOnly}
         >
-          <ModelSelection />
+          <ModelSelection temperatureRequired={quoteType !== "history"} />
           <ModelOption />
 
           <Form.Item label="其他备注" name="remark">

--- a/src/components/quoteForm/MeteringPumpForm/ModelSelection.tsx
+++ b/src/components/quoteForm/MeteringPumpForm/ModelSelection.tsx
@@ -17,7 +17,11 @@ import MaterialSelect from "@/components/general/MaterialSelect";
 import { useProductStore } from "@/store/useProductStore";
 import ExtruderForm from "../formComponents/ExtruderForm";
 
-export const ModelSelection = () => {
+export const ModelSelection = ({
+  temperatureRequired = true,
+}: {
+  temperatureRequired?: boolean;
+}) => {
   const pump = useProductStore((state) => state.pump);
   const fetchPump = useProductStore((state) => state.fetchPump);
   useEffect(() => {
@@ -57,7 +61,11 @@ export const ModelSelection = () => {
             <IntervalInputFormItem
               name="temperature"
               label="工艺温度(℃)"
-              rules={[{ required: true, message: "请输入工艺温度" }]}
+              rules={
+                temperatureRequired
+                  ? [{ required: true, message: "请输入工艺温度" }]
+                  : []
+              }
               placeholder={"工艺温度"}
               addonAfter="℃"
             />

--- a/src/components/quoteForm/dieForm/DieBody.tsx
+++ b/src/components/quoteForm/dieForm/DieBody.tsx
@@ -170,16 +170,22 @@ export const DieBody = () => {
             />
           </Form.Item>
         </Col>
-        <Col xs={12} md={6}>
-          <Form.Item
-            name="lipCount"
-            label="模唇数量"
-            rules={[{ required: true, message: "请输入模唇数量" }]}
-            initialValue={1}
-          >
-            <InputNumber min={1} max={5} style={{ width: "100%" }} />
-          </Form.Item>
-        </Col>
+        <Form.Item noStyle dependencies={["lowerLipStructure"]}>
+          {({ getFieldValue }) =>
+            getFieldValue("lowerLipStructure")?.includes("整体") ? null : (
+              <Col xs={12} md={6}>
+                <Form.Item
+                  name="lipCount"
+                  label="模唇数量"
+                  rules={[{ required: true, message: "请输入模唇数量" }]}
+                  initialValue={1}
+                >
+                  <InputNumber min={1} max={5} style={{ width: "100%" }} />
+                </Form.Item>
+              </Col>
+            )
+          }
+        </Form.Item>
         <Col xs={24} md={24}>
           <ProFormDependency name={["lipCount"]}>
             {({ lipCount }) =>

--- a/src/components/quoteForm/dieForm/DieForm.tsx
+++ b/src/components/quoteForm/dieForm/DieForm.tsx
@@ -167,6 +167,13 @@ const DieForm = forwardRef(
       if (!result.result) form.setFieldValue("thicknessGauge", true);
     };
 
+    const handleLowerLipStructure = (value: string) => {
+      if (value?.includes("整体")) {
+        form.setFieldValue("lipCount", 1);
+        handleLipCount(1);
+      }
+    };
+
     const handleLipCount = (value: number) => {
       const count = value ?? 1;
       if (count <= 1) {
@@ -191,6 +198,7 @@ const DieForm = forwardRef(
         smartRegulator: handleSmartRegulator,
         haveThermalInsulation: handleThermalInsulation,
         thicknessGauge: handleThicknessGauge,
+        lowerLipStructure: handleLowerLipStructure,
         lipCount: handleLipCount,
       };
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -64,6 +64,7 @@ export interface Quote {
   projectManagerId: string; // 项目管理id
   totalProductPrice: number; // 产品价格合计
   discountAmount: number; // 优惠金额
+  hideItemPrice?: boolean; // 是否隐藏分项价格
   quoteAmount: number; // 报价单金额
   deliveryDays: number; // 交期天数
   address: any; // 地址


### PR DESCRIPTION
## Summary
- allow hiding itemized pricing in QuoteConfigTab
- make temperature optional for history quotes in the metering pump form
- hide lip count when lower lip structure is integral
- adjust die form logic to reset lip count when needed
- expose option for temperature requirement in pump model selection
- define `hideItemPrice` on quote types

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685cc4001554832797840bbcbdb76a40