### PR TITLE
Add sender contact fields and print validations

### DIFF
--- a/src/api/services/quote.service.ts
+++ b/src/api/services/quote.service.ts
@@ -16,6 +16,8 @@ export const QuoteService = {
     quoteName: string;
     contactName?: string;
     contactPhone?: string;
+    senderId?: string;
+    senderPhone?: string;
   }) {
     const quote = await apiClient.post("/quote/create", {
       ...params,

--- a/src/components/quote/QuoteConfigTab.tsx
+++ b/src/components/quote/QuoteConfigTab.tsx
@@ -21,6 +21,18 @@ import QuoteItemsTable from "./QuoteItemsTable";
 import { Quote } from "@/types/types";
 import { selectOptions } from "@/util/valueUtil";
 
+const SENDER_PHONE_OPTIONS = [
+  { value: "0576-84610021", label: "蔡:0576-84610021" },
+  { value: "0576-84610010", label: "阮:0576-84610010" },
+  { value: "0576-84610019", label: "辛:0576-84610019" },
+  { value: "0576-84610007", label: "张1:0576-84610007" },
+  { value: "0576-84025778", label: "张2:0576-84025778" },
+  { value: "0576-84610008", label: "杨:0576-84610008" },
+  { value: "0576-84610003", label: "闫:0576-84610003" },
+  { value: "0576-84025988", label: "卞:0576-84025988" },
+  { value: "0576-84610002", label: "卓:0576-84610002" },
+];
+
 const INDUSTRY = {
   新能源及储能: ["动力电池（锂电、氢燃料、钠电）", "光伏新能源"],
   半导体及电子元器件: ["半导体（泛半导体）", "先进封装", "高端显示"],
@@ -316,6 +328,20 @@ const QuoteConfigTab: React.FC<QuoteConfigTabProps> = ({
               rules={[{ required: true, message: "请输入联系人手机号" }]}
             >
               <AutoComplete options={phoneOptions} />
+            </Form.Item>
+          </Col>
+          <Col xs={12} md={6}>
+            <Form.Item
+              name="senderId"
+              label="发送人"
+              initialValue={quote?.salesSupportId}
+            >
+              <MemberSelect placeholder="选择发送人" />
+            </Form.Item>
+          </Col>
+          <Col xs={12} md={6}>
+            <Form.Item name="senderPhone" label="发送人电话">
+              <AutoComplete options={SENDER_PHONE_OPTIONS} />
             </Form.Item>
           </Col>
           <Col xs={12} md={8}>

--- a/src/components/quote/QuoteForm.tsx
+++ b/src/components/quote/QuoteForm.tsx
@@ -269,6 +269,14 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
 
   const print = async (type: "config" | "quote" | "contract") => {
     if (!quote?.id) return;
+    if (type === "quote" && quoteTerms.length === 0) {
+      message.error("请设置至少一条报价条约");
+      return;
+    }
+    if (type === "contract" && contractTerms.length === 0) {
+      message.error("请设置合同条款");
+      return;
+    }
     setPreviewLoading(true);
     try {
       const apiType = type === "quote" ? "quotation" : type;

--- a/src/store/useQuoteStore.ts
+++ b/src/store/useQuoteStore.ts
@@ -80,6 +80,8 @@ interface QuotesStore {
     quoteName: string;
     contactName?: string;
     contactPhone?: string;
+    senderId?: string;
+    senderPhone?: string;
   }) => Promise<Quote>;
   updateQuote: (
     quoteId: number,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -70,6 +70,8 @@ export interface Quote {
   address: any; // 地址
   contactName: string; // 联系人姓名
   contactPhone: string; // 联系人手机号
+  senderId?: string; // 发送人id
+  senderPhone?: string; // 发送人电话
   telephone?: string; // 电话
   faxNumber?: string; // 传真号
   technicalLevel: string; // 技术等级


### PR DESCRIPTION
## Summary
- enforce quote/contract terms when printing
- add sender selection and phone autocomplete in quote form
- provide sender phone options
- track sender info in quote model

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d16647b9c832795d8d9c47f308bd4