### PR TITLE
Enhance contact autocomplete

### DIFF
--- a/src/api/services/customer.service.ts
+++ b/src/api/services/customer.service.ts
@@ -30,7 +30,26 @@ export const CustomerService = {
     const res = await apiClient.get("/customer/contact/get", {
       params: { id },
     });
-    return res.data as { contacts: any[]; address: any };
+    const data = res.data as {
+      contact?: any[];
+      general?: { fax?: string[]; address?: string[] };
+    };
+    const contacts = (data?.contact ?? []).map((item: any) => ({
+      name: item.contact ?? item.name,
+      phone: item.phone,
+      address: item.address,
+      fax: item.fax,
+    }));
+    return {
+      contacts,
+      general: {
+        fax: data?.general?.fax ?? [],
+        address: data?.general?.address ?? [],
+      },
+    } as {
+      contacts: any[];
+      general: { fax: string[]; address: string[] };
+    };
   },
   async matchCustomer(payload: {
     externalUserId: string;

--- a/src/components/quote/QuoteConfigTab.tsx
+++ b/src/components/quote/QuoteConfigTab.tsx
@@ -87,6 +87,8 @@ interface QuoteConfigTabProps {
   quote?: Quote;
   nameOptions: { value: string; label: string }[];
   phoneOptions: { value: string; label: string }[];
+  faxOptions: { value: string; label: string }[];
+  addressOptions: { value: string; label: string }[];
   handleNameSelect: (value: string) => void;
 }
 
@@ -95,6 +97,8 @@ const QuoteConfigTab: React.FC<QuoteConfigTabProps> = ({
   quote,
   nameOptions,
   phoneOptions,
+  faxOptions,
+  addressOptions,
   handleNameSelect,
 }) => {
   const onDateChange = (date: any) => {
@@ -350,13 +354,21 @@ const QuoteConfigTab: React.FC<QuoteConfigTabProps> = ({
             </Form.Item>
           </Col>
           <Col xs={12} md={8}>
-            <Form.Item name="faxNumber" label="传真号">
-              <Input />
+            <Form.Item
+              name="faxNumber"
+              label="传真号"
+              rules={[{ required: true, message: "请输入传真号" }]}
+            >
+              <AutoComplete options={faxOptions} />
             </Form.Item>
           </Col>
           <Col xs={24} md={24}>
-            <Form.Item name="address" label="地址">
-              <AddressInput />
+            <Form.Item
+              name="address"
+              label="地址"
+              rules={[{ required: true, message: "请输入地址" }]}
+            >
+              <AddressInput addressOptions={addressOptions} />
             </Form.Item>
           </Col>
         </Row>

--- a/src/components/quote/QuoteForm.tsx
+++ b/src/components/quote/QuoteForm.tsx
@@ -161,6 +161,12 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
   const [phoneOptions, setPhoneOptions] = useState<
     { value: string; label: string }[]
   >([]);
+  const [faxOptions, setFaxOptions] = useState<
+    { value: string; label: string }[]
+  >([]);
+  const [addressOptions, setAddressOptions] = useState<
+    { value: string; label: string }[]
+  >([]);
   const [preview, setPreview] = useState<{ blob: Blob; type: string } | null>(
     null
   );
@@ -196,9 +202,12 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
       setPhoneOptions(
         list.map((c: any) => ({ value: c.phone, label: c.phone }))
       );
-      if (data.address) {
-        form.setFieldsValue({ address: data.address });
-      }
+      setFaxOptions(
+        (data?.general?.fax ?? []).map((f: string) => ({ value: f, label: f }))
+      );
+      setAddressOptions(
+        (data?.general?.address ?? []).map((a: string) => ({ value: a, label: a }))
+      );
     } catch (e) {
       console.error(e);
     }
@@ -208,9 +217,19 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
     const matched = contacts.filter((c) => c.name === value);
     const phones = matched.map((c) => c.phone);
     setPhoneOptions(phones.map((p) => ({ value: p, label: p })));
+    const addresses = matched.map((c) => c.address).filter(Boolean);
+    const faxes = matched.map((c) => c.fax).filter(Boolean);
     if (phones.length === 1) {
       form.setFieldsValue({ contactPhone: phones[0] });
       if (quote) updateQuote(quote.id, { contactPhone: phones[0] });
+    }
+    if (addresses.length === 1) {
+      form.setFieldsValue({ address: addresses[0] });
+      if (quote) updateQuote(quote.id, { address: addresses[0] as any });
+    }
+    if (faxes.length === 1) {
+      form.setFieldsValue({ faxNumber: faxes[0] });
+      if (quote) updateQuote(quote.id, { faxNumber: faxes[0] });
     }
   };
 
@@ -372,6 +391,8 @@ const QuoteForm: React.FC<QuoteFormProps> = ({
                 quote={quote}
                 nameOptions={nameOptions}
                 phoneOptions={phoneOptions}
+                faxOptions={faxOptions}
+                addressOptions={addressOptions}
                 handleNameSelect={handleNameSelect}
               />
             ),


### PR DESCRIPTION
## Summary
- integrate new contact API structure
- autofill phone, address and fax when selecting a contact
- offer autocomplete options for fax and address
- mark fax and address as required fields

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing type definition files)*

------
https://chatgpt.com/codex/tasks/task_e_685d1d82110c8327ad99f4052ac41de3