### PR TITLE
Rename composite ratio field

### DIFF
--- a/scripts/form_fields.json
+++ b/scripts/form_fields.json
@@ -66,7 +66,7 @@
       "type": "ProFormList"
     },
     {
-      "name": "compositeRatio",
+      "name": "runnerLayers",
       "label": "每层复合比例",
       "type": "ProFormList"
     }
@@ -352,8 +352,13 @@
       "type": "CustomSelect"
     },
     {
+      "name": "extrudeType",
+      "label": "挤出类型",
+      "type": "Select"
+    },
+    {
       "name": "runnerNumber",
-      "label": "模内共挤层数",
+      "label": "层数",
       "type": "InputNumber"
     },
     {
@@ -367,7 +372,7 @@
       "type": "Radio.Group"
     },
     {
-      "name": "compositeRatio",
+      "name": "runnerLayers",
       "label": "每层复合比例",
       "type": "ProFormList"
     },

--- a/src/components/general/MaterialSelect.tsx
+++ b/src/components/general/MaterialSelect.tsx
@@ -6,6 +6,10 @@ interface MaterialSelectProps {
   id?: string;
   value?: string[];
   onChange?: (value: string[]) => void;
+  /**
+   * Custom option groups. Keys are group titles and values are
+   * option labels. When omitted the default MATERIAL groups are used.
+   */
   options?: Record<string, string[]>;
   disabled?: boolean;
   placeholder?: string;
@@ -21,6 +25,7 @@ const MaterialSelect: React.FC<MaterialSelectProps> = ({
   id,
   value = [],
   onChange,
+  options,
   disabled = false,
   placeholder = "输入材料，按回车确认",
   style,
@@ -51,7 +56,7 @@ const MaterialSelect: React.FC<MaterialSelectProps> = ({
       disabled={disabled}
       mode="tags"
       onInputKeyDown={handleInputKeyDown}
-      options={selectOptions(MATERIAL)}
+      options={selectOptions(options ?? MATERIAL)}
       value={value}
       onChange={handleChange}
       style={{ ...style, width: "100%" }}

--- a/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
+++ b/src/components/quote/ProductConfigForm/ProductConfigurationForm.tsx
@@ -72,10 +72,17 @@ const ProductConfigurationForm = forwardRef(
           typeof upperLip === "string" && upperLip.includes("自动")
             ? "自动"
             : "手动";
+        const extrudeType = modelFormRef.current?.form.getFieldValue(
+          "extrudeType"
+        );
         const runnerNumber =
           modelFormRef.current?.form.getFieldValue("runnerNumber") ?? 0;
         const runnerStr =
-          runnerNumber && runnerNumber > 1 ? `${runnerNumber}层模内共挤` : "";
+          extrudeType &&
+          ["模内共挤", "分配器+模内共挤"].includes(extrudeType) &&
+          runnerNumber > 1
+            ? `${runnerNumber}层${extrudeType}`
+            : "";
         const final = finalProduct ?? "";
         return `${widthStr}${mat}${runnerStr}${final}${manualOrAuto}模头`;
       }

--- a/src/components/quoteForm/dieForm/DieForm.tsx
+++ b/src/components/quoteForm/dieForm/DieForm.tsx
@@ -10,7 +10,6 @@ import ProForm from "@ant-design/pro-form";
 import TextArea from "antd/es/input/TextArea";
 import useProductActionModal from "@/hook/showProductActionModal";
 import { useQuoteStore } from "@/store/useQuoteStore";
-import { LevelValue } from "@/components/general/LevelInputNumber";
 interface PriceFormRef {
   form: FormInstance; // 明确定义暴露的form实例
 }
@@ -81,30 +80,17 @@ const DieForm = forwardRef(
     const handleCompositeStructure = (value: string) => {
       const list = value.split("").map((s: any) => ({ layer: s }));
       form.setFieldValue("screwList", list);
-
-      const ratioList = (form.getFieldValue("compositeRatio") ||
-        []) as LevelValue[];
-      const base = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-      const len = form.getFieldValue("runnerNumber") || value.length;
-      const ratioNext = Array.from({ length: len }, (_, i) => ({
-        level: base[i],
-      }));
-      form.setFieldValue(
-        "compositeRatio",
-        ratioList.slice(0, len).concat(ratioNext.slice(ratioList.length))
-      );
     };
 
     const handleRunnerNumber = (value: number) => {
-      const ratioList = (form.getFieldValue("compositeRatio") ||
-        []) as LevelValue[];
+      const ratioList = (form.getFieldValue("runnerLayers") || []) as any[];
       const base = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
       const len = value;
       const ratioNext = Array.from({ length: len }, (_, i) => ({
         level: base[i],
       }));
       form.setFieldValue(
-        "compositeRatio",
+        "runnerLayers",
         ratioList.slice(0, len).concat(ratioNext.slice(ratioList.length))
       );
     };

--- a/src/components/quoteForm/formComponents/RunnerLayerItem.tsx
+++ b/src/components/quoteForm/formComponents/RunnerLayerItem.tsx
@@ -1,0 +1,81 @@
+import ProForm from "@ant-design/pro-form";
+import { Col, Row, Input, InputNumber } from "antd";
+import { IntervalInput } from "@/components/general/IntervalInput";
+import MaterialSelect from "@/components/general/MaterialSelect";
+
+interface RunnerLayerItemProps {
+  /** 可选材料列表 */
+  materials?: string[];
+}
+const RunnerLayerItem: React.FC<RunnerLayerItemProps> = ({ materials }) => {
+  return (
+    <Row gutter={16}>
+      <Col xs={24} md={6}>
+        <ProForm.Item name="level" label="层" readonly>
+          <Input disabled />
+        </ProForm.Item>
+      </Col>
+      <Col xs={24} md={6}>
+        <ProForm.Item
+          name="value"
+          label="比例"
+          rules={[
+            {
+              validator: async (_: any, value: { value?: string; front?: number; rear?: number }) => {
+                const num = parseFloat(value?.value || "0");
+                if (isNaN(num) || num === 0) {
+                  return Promise.reject(new Error("比例不得为0"));
+                }
+                if (
+                  (value?.front !== undefined && value.front >= 100) ||
+                  (value?.rear !== undefined && value.rear >= 100)
+                ) {
+                  return Promise.reject(new Error("比例不得超过100"));
+                }
+                if (
+                  value?.front !== undefined &&
+                  value?.rear !== undefined &&
+                  value.front >= value.rear
+                ) {
+                  return Promise.reject(new Error("第一个应比第二个小"));
+                }
+                return Promise.resolve();
+              },
+            },
+          ]}
+        >
+          <IntervalInput unit="%" style={{ width: 120 }} />
+        </ProForm.Item>
+      </Col>
+      <Col xs={24} md={6}>
+        <ProForm.Item
+          name="temperature"
+          label="工艺温度(℃)"
+          rules={[{ required: true, message: "请输入工艺温度" }]}
+        >
+          <InputNumber
+            formatter={(value) => `${value}℃`}
+            parser={(value) => value?.replace(/℃/g, "") as any}
+            min={0}
+            precision={0}
+            style={{ width: "100%" }}
+          />
+        </ProForm.Item>
+      </Col>
+      <Col xs={24} md={6}>
+        <ProForm.Item
+          name="material"
+          label="材料"
+          rules={[{ required: true, message: "请选择材料" }]}
+        >
+          <MaterialSelect
+            options={materials ? { 可选材料: materials } : undefined}
+            placeholder="请选择材料"
+          />
+        </ProForm.Item>
+      </Col>
+    </Row>
+  );
+};
+
+export default RunnerLayerItem;


### PR DESCRIPTION
## Summary
- rename `CompositeRatioItem` to `RunnerLayerItem`
- rename form field `compositeRatio` to `runnerLayers`
- remove composite structure dependency for the runner layers list
- pass material list to the updated component
- adjust runner types and add extrude type selection
- remove LevelInputNumber from RunnerLayerItem and expose auto-generated level column

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails due to missing type declarations and dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685d850a7a4c832783ab8047603894b8