### PR TITLE
Add import information tracking

### DIFF
--- a/src/components/quote/ProductConfigForm/ProductConfigModal.tsx
+++ b/src/components/quote/ProductConfigForm/ProductConfigModal.tsx
@@ -150,7 +150,11 @@ const ProductConfigModal: React.FC<ProductConfigModalProps> = ({
               alignItems: "center",
             }}
           >
-            <span>{quoteItem?.productCategory?.join("/")}</span>
+            <span>
+              {quoteItem?.productCategory?.join("/")}
+              {quoteItem?.importInfo &&
+                `(${quoteItem.importInfo.id} ${quoteItem.importInfo.name})`}
+            </span>
             <Button
               type="link"
               onClick={() => setImportOpen(true)}
@@ -197,13 +201,17 @@ const ProductConfigModal: React.FC<ProductConfigModalProps> = ({
           open={importOpen}
           onCancel={() => setImportOpen(false)}
           onImport={(item) => {
-            // update current form instead of store so modal stays open
             if (item.config) {
               formRef.current?.modelForm?.setFieldsValue(item.config);
             }
             if (item.productName) {
               formRef.current?.priceForm?.setFieldsValue({
                 productName: item.productName,
+              });
+            }
+            if (quoteItem?.id && item.importInfo) {
+              onUpdateItem(quoteId, quoteItem.id, {
+                importInfo: item.importInfo,
               });
             }
             setImportOpen(false);

--- a/src/components/quoteForm/dieForm/DieForm.tsx
+++ b/src/components/quoteForm/dieForm/DieForm.tsx
@@ -1,5 +1,5 @@
 import { Form, FormInstance } from "antd";
-import { forwardRef, useImperativeHandle } from "react";
+import { forwardRef, useImperativeHandle, useState } from "react";
 import { Product } from "./Product";
 import { DieBody } from "./DieBody";
 import { DieInstall } from "./DieInstall";
@@ -25,6 +25,7 @@ const DieForm = forwardRef(
     ref
   ) => {
     const [form] = Form.useForm();
+    const [locked, setLocked] = useState(false);
     const quoteItems = useQuoteStore
       .getState()
       .quotes.find((quote) => quote.id === quoteId)?.items;
@@ -216,9 +217,13 @@ const DieForm = forwardRef(
           form={form}
           submitter={false}
           onValuesChange={handleFieldsChange}
-          disabled={readOnly}
+          disabled={readOnly || locked}
         >
-          <SameProduct />
+          <SameProduct
+            quoteId={quoteId}
+            quoteItemId={quoteItemId}
+            onLockChange={setLocked}
+          />
           <Form.Item noStyle dependencies={["isBuySameProduct"]}>
             {({ getFieldValue }) => {
               const isBuySameProduct = getFieldValue("isBuySameProduct");

--- a/src/components/quoteForm/dieForm/SameProduct.tsx
+++ b/src/components/quoteForm/dieForm/SameProduct.tsx
@@ -1,58 +1,126 @@
-import { Col, Form, Input, Radio, Row } from "antd";
+import { Button, Col, Form, Input, Row } from "antd";
 import { useState } from "react";
+import ImportProductModal from "@/components/quote/ProductConfigForm/ImportProductModal";
 
-export const SameProduct = () => {
-  const [isBuySameProduct, setIsBuySameProduct] = useState<boolean>(false);
-  const [isIntercompatible, setIsIntercompatible] = useState<boolean>(false);
+interface SameProductProps {
+  quoteId: number;
+  quoteItemId: number;
+  onLockChange?: (locked: boolean) => void;
+}
+
+export const SameProduct: React.FC<SameProductProps> = ({
+  quoteId,
+  quoteItemId,
+  onLockChange,
+}) => {
+  const form = Form.useFormInstance();
+  const [sameOpen, setSameOpen] = useState(false);
+  const [interOpen, setInterOpen] = useState(false);
+  const [sameSelected, setSameSelected] = useState(false);
+  const [interSelected, setInterSelected] = useState(false);
+
+  const handleSameSelect = (item: any) => {
+    form.setFieldsValue({
+      isBuySameProduct: true,
+      lastProductCode: item.productCode,
+    });
+    setSameSelected(true);
+    setSameOpen(false);
+    onLockChange?.(true);
+  };
+
+  const handleInterSelect = (item: any) => {
+    form.setFieldsValue({
+      isIntercompatible: true,
+      intercompatibleProductCode: item.productCode,
+    });
+    setInterSelected(true);
+    setInterOpen(false);
+  };
+
   return (
-    <Row gutter={16}>
-      <Col xs={12} md={8}>
-        <Form.Item
-          name="isBuySameProduct"
-          label="是否购买过相同型号产品"
-          rules={[{ required: true, message: "是否购买过相同型号产品" }]}
-        >
-          <Radio.Group onChange={(e) => setIsBuySameProduct(e.target.value)}>
-            <Radio value={true}>是</Radio>
-            <Radio value={false}>否</Radio>
-          </Radio.Group>
-        </Form.Item>
-      </Col>
-      {isBuySameProduct ? (
+    <>
+      <Row gutter={16}>
         <Col xs={12} md={8}>
-          <Form.Item
-            name="lastProductCode"
-            label="同型号产品编号"
-            rules={[{ required: true, message: "请输入原产品名称编号" }]}
+          <Button
+            danger={sameSelected}
+            type={sameSelected ? "primary" : "default"}
+            onClick={() => {
+              if (sameSelected) {
+                form.setFieldsValue({
+                  isBuySameProduct: false,
+                  lastProductCode: undefined,
+                });
+                setSameSelected(false);
+                onLockChange?.(false);
+              } else {
+                setSameOpen(true);
+              }
+            }}
           >
-            <Input />
-          </Form.Item>
+            {sameSelected ? "取消相同产品" : "选择相同产品编号"}
+          </Button>
         </Col>
-      ) : (
-        <Col xs={12} md={8}>
-          <Form.Item
-            name="isIntercompatible"
-            label="是否与购买过的产品互配"
-            rules={[{ required: true, message: "是否与原购买过的产品互配" }]}
-          >
-            <Radio.Group onChange={(e) => setIsIntercompatible(e.target.value)}>
-              <Radio value={true}>是</Radio>
-              <Radio value={false}>否</Radio>
-            </Radio.Group>
-          </Form.Item>
-        </Col>
-      )}
-      {!isBuySameProduct && isIntercompatible && (
-        <Col xs={12} md={8}>
-          <Form.Item
-            name="intercompatibleProductCode"
-            label="互配产品编号"
-            rules={[{ required: true, message: "请输入原产品名称编号" }]}
-          >
-            <Input />
-          </Form.Item>
-        </Col>
-      )}
-    </Row>
+        {sameSelected && (
+          <Col xs={12} md={8}>
+            <Form.Item
+              name="lastProductCode"
+              label="同型号产品编号"
+              rules={[{ required: true, message: "请输入原产品名称编号" }]}
+            >
+              <Input disabled />
+            </Form.Item>
+          </Col>
+        )}
+        {!sameSelected && (
+          <Col xs={12} md={8}>
+            <Button
+              danger={interSelected}
+              type={interSelected ? "primary" : "default"}
+              onClick={() => {
+                if (interSelected) {
+                  form.setFieldsValue({
+                    isIntercompatible: false,
+                    intercompatibleProductCode: undefined,
+                  });
+                  setInterSelected(false);
+                } else {
+                  setInterOpen(true);
+                }
+              }}
+            >
+              {interSelected ? "取消互配产品" : "选择互配产品编号"}
+            </Button>
+          </Col>
+        )}
+        {!sameSelected && interSelected && (
+          <Col xs={12} md={8}>
+            <Form.Item
+              name="intercompatibleProductCode"
+              label="互配产品编号"
+              rules={[{ required: true, message: "请输入原产品名称编号" }]}
+            >
+              <Input disabled />
+            </Form.Item>
+          </Col>
+        )}
+      </Row>
+      <ImportProductModal
+        open={sameOpen}
+        onCancel={() => setSameOpen(false)}
+        onImport={handleSameSelect}
+        formType="DieForm"
+        orderOnly
+      />
+      <ImportProductModal
+        open={interOpen}
+        onCancel={() => setInterOpen(false)}
+        onImport={handleInterSelect}
+        formType="DieForm"
+        orderOnly
+      />
+    </>
   );
 };
+
+export default SameProduct;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -122,6 +122,11 @@ export interface QuoteItem {
     value: any;
     key: string;
   };
+  importInfo?: {
+    type: "template" | "order";
+    name: string;
+    id: string;
+  };
   isCategoryLocked: boolean;
 }
 


### PR DESCRIPTION
## Summary
- add `importInfo` field to quote items
- support `orderOnly` mode in import modal
- show import source in product config title and save when importing
- update `SameProduct` to use buttons and import modal
- disable die form on same product selection

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68639dd468f883279431d5804104a1ae