### PR TITLE
Implement template pagination

### DIFF
--- a/src/api/services/template.service.ts
+++ b/src/api/services/template.service.ts
@@ -2,9 +2,13 @@ import { apiClient } from "../http/client";
 import { QuoteTemplate } from "@/types/types";
 
 export const TemplateService = {
-  async getTemplates(params?: { formType?: string }) {
+  async getTemplates(params?: {
+    formType?: string;
+    page?: number;
+    pageSize?: number;
+  }) {
     const res = await apiClient.get("/template/get", { params });
-    return res.data as QuoteTemplate[];
+    return res.data as { list: QuoteTemplate[]; total: number };
   },
   async getTemplate(id: string) {
     const res = await apiClient.get("/template/detail/get", { params: { id } });

--- a/src/components/template/TemplateTable.tsx
+++ b/src/components/template/TemplateTable.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Table } from "antd";
+import type { TablePaginationConfig } from "antd/es/table";
 import MemberAvatar from "../general/MemberAvatar";
 import { QuoteTemplate } from "@/types/types";
 
@@ -11,6 +12,8 @@ interface TemplateTableProps {
   onDoubleClick?: (tpl: QuoteTemplate) => void;
   showType?: boolean;
   actionRender?: (tpl: QuoteTemplate) => React.ReactNode;
+  pagination?: false | TablePaginationConfig;
+  onPageChange?: (page: number, pageSize: number) => void;
 }
 
 const TEMPLATE_TYPE_MAP: Record<string, string> = {
@@ -33,6 +36,8 @@ const TemplateTable: React.FC<TemplateTableProps> = ({
   onDoubleClick,
   showType = true,
   actionRender,
+  pagination = false,
+  onPageChange,
 }) => {
   const columns = [
     { title: "ID", dataIndex: "id", width: 80 },
@@ -76,7 +81,12 @@ const TemplateTable: React.FC<TemplateTableProps> = ({
       dataSource={templates}
       columns={columns as any}
       loading={loading}
-      pagination={false}
+      pagination={pagination}
+      onChange={(p: TablePaginationConfig) => {
+        if (onPageChange && p.current && p.pageSize) {
+          onPageChange(p.current, p.pageSize);
+        }
+      }}
       onRow={(record) => ({
         onClick: () => onSelect?.(record),
         onDoubleClick: () => onDoubleClick?.(record),

--- a/src/store/useTemplateStore.ts
+++ b/src/store/useTemplateStore.ts
@@ -20,8 +20,8 @@ export const useTemplateStore = create<TemplateState>()(
     },
     refreshTemplates: async (formType?: string) => {
       set({ loading: true });
-      const data = await TemplateService.getTemplates({ formType });
-      set({ templates: data, loading: false });
+      const { list } = await TemplateService.getTemplates({ formType });
+      set({ templates: list, loading: false });
     },
   }))
 );


### PR DESCRIPTION
## Summary
- update TemplateService to support paginated queries
- add pagination controls in `TemplateTable`
- support page loading in `ImportProductModal`
- show product code column when importing from other products
- adapt template store for new API response

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npx tsc -p tsconfig.json --noEmit` *(fails: network restrictions prevented package installation)*

------
https://chatgpt.com/codex/tasks/task_e_6863fa672d0883278307dc85fa569f48