### PR TITLE
Add pagination for product import search

### DIFF
--- a/src/api/services/product.service.ts
+++ b/src/api/services/product.service.ts
@@ -5,11 +5,13 @@ export const ProductService = {
   async searchProducts(
     keyword: string,
     field: "code" | "name",
-    formType?: string
+    formType?: string,
+    page = 1,
+    pageSize = 10
   ) {
     const res = await apiClient.get("/product/search", {
-      params: { keyword, field, formType },
+      params: { keyword, field, formType, page, pageSize },
     });
-    return res.data as ProductSearchResult[];
+    return res.data as { list: ProductSearchResult[]; total: number };
   },
 };


### PR DESCRIPTION
## Summary
- support paginated search in `ProductService`
- implement pagination in `ImportProductModal` when importing from other products
- add `Pagination` component below results table

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6863ff41d700832793748b0bc9cb833f