### PR TITLE
Fix formType sync for template import

### DIFF
--- a/src/components/quote/DesktopQuoteItemsTable.tsx
+++ b/src/components/quote/DesktopQuoteItemsTable.tsx
@@ -6,6 +6,7 @@ import { formatPrice } from "@/util/valueUtil";
 import { isTextSelecting } from "@/util/domUtil";
 import ProductConfigModal from "./ProductConfigForm/ProductConfigModal";
 import { QuoteItem } from "@/types/types";
+import { getFormType } from "./ProductConfigForm/formSelector";
 import { useMemo, useState } from "react";
 import SortableTable, { DragHandle } from "../general/SortableTable";
 import { SortableColumn } from "../general/SortableColumn";
@@ -62,10 +63,12 @@ const DesktopQuoteItemsTable: React.FC<QuoteItemsTableProps> = ({
     if (value[0] == "平模" || value[0] == "配套件") {
       productName = "";
     }
+    const formType = getFormType(value);
     updateQuoteItem(quoteId, record.id, {
       productCategory: value,
       isCompleted: false,
       productName,
+      formType,
     });
   };
   const [open, setOpen] = useState(false);


### PR DESCRIPTION
## Summary
- sync `formType` when changing product category so template import button works

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6864032514208327b05baf9237fef2be