### PR TITLE
Add order item import for history quotes

### DIFF
--- a/src/api/services/order.service.ts
+++ b/src/api/services/order.service.ts
@@ -3,6 +3,12 @@ import { apiClient } from "../http/client";
 export const OrderService = {
   async getOrderInfo(orderId: string) {
     const res = await apiClient.get("/order/get", { params: { orderId } });
-    return res.data;
+    const data = res.data as any;
+    return {
+      ...data,
+      items: data.items ?? [],
+    } as {
+      items: { productCode: string; name: string }[];
+    } & typeof data;
   },
 };

--- a/src/components/quote/AddHistoryModal.tsx
+++ b/src/components/quote/AddHistoryModal.tsx
@@ -15,10 +15,11 @@ export const AddHistoryModal = () => {
   const { message } = App.useApp();
   const navigate = useNavigate();
   const [form] = Form.useForm();
-  const { createQuote } = useQuoteStore();
+  const { createQuote, addQuoteItem } = useQuoteStore();
   const members = useMemberStore((state) => state.members);
   const fetchMembers = useMemberStore((state) => state.fetchMembers);
   const [modalVisible, setModalVisible] = useState(false);
+  const [items, setItems] = useState<{ productCode: string; name: string }[]>([]);
 
   const findMemberIdByName = (name: string) => {
     return members.find((m) => m.name === name)?.id;
@@ -29,6 +30,7 @@ export const AddHistoryModal = () => {
     try {
       await fetchMembers();
       const data = await OrderService.getOrderInfo(value);
+      setItems(data.items ?? []);
       form.setFieldsValue({
         orderId: data["订单号"],
         customer: { name: data["客户名称"], erpId: data["客户ID"] },
@@ -64,6 +66,14 @@ export const AddHistoryModal = () => {
         contactName: values.contactName,
         contactPhone: values.contactPhone,
       });
+      if (quote?.id && items.length > 0) {
+        for (const item of items) {
+          await addQuoteItem(quote.id, {
+            productCode: item.productCode,
+            productName: item.name,
+          });
+        }
+      }
       message.success("历史报价单添加成功");
       form.resetFields();
       if (quote?.id) {


### PR DESCRIPTION
## Summary
- support items when fetching order info
- store fetched items in AddHistoryModal and create quote items on submit

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6864911d94488327beb44581a35342ad