### PR TITLE
Add loading overlay for history quote

### DIFF
--- a/src/components/quote/AddHistoryModal.tsx
+++ b/src/components/quote/AddHistoryModal.tsx
@@ -1,4 +1,4 @@
-import { Modal, Input, DatePicker, Form, Button, Row, Col, App } from "antd";
+import { Modal, Input, DatePicker, Form, Button, Row, Col, App, Spin } from "antd";
 import InputWithButton from "../general/InputWithButton";
 import { CustomerService } from "@/api/services/customer.service";
 import { OrderService } from "@/api/services/order.service";
@@ -20,6 +20,7 @@ export const AddHistoryModal = () => {
   const fetchMembers = useMemberStore((state) => state.fetchMembers);
   const [modalVisible, setModalVisible] = useState(false);
   const [items, setItems] = useState<{ productCode: string; name: string }[]>([]);
+  const [loading, setLoading] = useState(false);
 
   const findMemberIdByName = (name: string) => {
     return members.find((m) => m.name === name)?.id;
@@ -52,6 +53,7 @@ export const AddHistoryModal = () => {
   const handleSubmit = async () => {
     try {
       const values = await form.validateFields();
+      setLoading(true);
       setModalVisible(false);
       const quote = await createQuote({
         ...values,
@@ -79,6 +81,7 @@ export const AddHistoryModal = () => {
       if (quote?.id) {
         navigate(`/quote/${quote.id}`);
       }
+      setLoading(false);
     } catch (error: any) {
       if (
         error?.response?.data?.message &&
@@ -88,10 +91,16 @@ export const AddHistoryModal = () => {
       }
       console.error("添加历史报价单失败:", error);
       message.error("添加历史报价单失败");
+      setLoading(false);
     }
   };
   return (
     <>
+      {loading && (
+        <div className="full-page-spin">
+          <Spin tip="加载中..." size="large" />
+        </div>
+      )}
       <div style={{ marginBottom: 16 }}>
         <Button type="primary" onClick={() => setModalVisible(true)}>
           添加历史报价单

--- a/src/index.css
+++ b/src/index.css
@@ -66,3 +66,16 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 } */
+
+.full-page-spin {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(255, 255, 255, 0.45);
+  z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- show an overlay spinner while importing history quotes
- style full-page overlay spinner

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6864e2ebdfa08327b3cc0fdaec10b6e8