### PR TITLE
Handle items in quote creation

### DIFF
--- a/src/api/services/quote.service.ts
+++ b/src/api/services/quote.service.ts
@@ -18,6 +18,7 @@ export const QuoteService = {
     contactPhone?: string;
     senderId?: string;
     senderPhone?: string;
+    items?: Partial<QuoteItem>[];
   }) {
     const quote = await apiClient.post("/quote/create", {
       ...params,

--- a/src/components/quote/AddHistoryModal.tsx
+++ b/src/components/quote/AddHistoryModal.tsx
@@ -15,7 +15,7 @@ export const AddHistoryModal = () => {
   const { message } = App.useApp();
   const navigate = useNavigate();
   const [form] = Form.useForm();
-  const { createQuote, addQuoteItem } = useQuoteStore();
+  const { createQuote } = useQuoteStore();
   const members = useMemberStore((state) => state.members);
   const fetchMembers = useMemberStore((state) => state.fetchMembers);
   const [modalVisible, setModalVisible] = useState(false);
@@ -67,15 +67,11 @@ export const AddHistoryModal = () => {
         quoteName: values.quoteName,
         contactName: values.contactName,
         contactPhone: values.contactPhone,
+        items: items.map((item) => ({
+          productCode: item.productCode,
+          productName: item.name,
+        })),
       });
-      if (quote?.id && items.length > 0) {
-        for (const item of items) {
-          await addQuoteItem(quote.id, {
-            productCode: item.productCode,
-            productName: item.name,
-          });
-        }
-      }
       message.success("历史报价单添加成功");
       form.resetFields();
       if (quote?.id) {

--- a/src/store/useQuoteStore.ts
+++ b/src/store/useQuoteStore.ts
@@ -82,6 +82,7 @@ interface QuotesStore {
     contactPhone?: string;
     senderId?: string;
     senderPhone?: string;
+    items?: Partial<QuoteItem>[];
   }) => Promise<Quote>;
   updateQuote: (
     quoteId: number,


### PR DESCRIPTION
## Summary
- allow items list parameter when creating a quote
- pass items directly from AddHistoryModal instead of calling `addQuoteItem`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686605652b688327a213f9b016584c01