### PR TITLE
Add coating die form

### DIFF
--- a/src/components/quote/ProductConfigForm/formSelector.tsx
+++ b/src/components/quote/ProductConfigForm/formSelector.tsx
@@ -7,6 +7,7 @@ import { OtherForm } from "@/components/quoteForm/OtherForm";
 import PartsForm from "@/components/quoteForm/PartsForm";
 import SmartRegulator from "@/components/quoteForm/SmartRegulator";
 import ThicknessGaugeForm from "@/components/quoteForm/ThicknessGaugeForm/ThicknessGaugeForm";
+import CoatingDieForm from "@/components/quoteForm/CoatingDieForm/CoatingDieForm";
 import React, { RefObject } from "react";
 
 export type ModelFormRef = RefObject<{ form: any } | null>;
@@ -19,6 +20,7 @@ export function getFormType(category: string[] | undefined | null): string {
   if (category?.at(1) == "过滤器") return "FilterForm";
   if (category?.at(1) == "测厚仪") return "ThicknessGaugeForm";
   if (category?.includes("液压站")) return "HydraulicStationForm";
+  if (category?.includes("涂布模头")) return "CoatingDieForm";
   if (category?.[1]?.includes("赠品")) return "PartsForm";
   return "OtherForm";
 }
@@ -108,6 +110,18 @@ export function getFormByCategory(
     return {
       form: (
         <HydraulicStationForm
+          ref={modelFormRef}
+          quoteId={quoteId}
+          quoteItemId={quoteItemId}
+          readOnly={readOnly}
+        />
+      ),
+      formType,
+    };
+  if (formType === "CoatingDieForm")
+    return {
+      form: (
+        <CoatingDieForm
           ref={modelFormRef}
           quoteId={quoteId}
           quoteItemId={quoteItemId}

--- a/src/components/quoteForm/CoatingDieForm/BasicInfo.tsx
+++ b/src/components/quoteForm/CoatingDieForm/BasicInfo.tsx
@@ -1,0 +1,64 @@
+import { Col, Form, Input, InputNumber, Radio, Row, AutoComplete, Select } from "antd";
+import { IntervalInputFormItem } from "@/components/general/IntervalInput";
+
+const PROCESS_OPTIONS = [
+  "锂电池涂布",
+  "氢能涂布",
+  "热熔胶涂布",
+  "陶瓷电容涂布",
+  "水处理膜涂布",
+  "钙钛矿涂布",
+  "半导体涂布",
+].map((v) => ({ label: v, value: v }));
+
+const MICRO_ADJUST = [
+  { label: "垫片调节", value: "垫片调节" },
+  { label: "差动调节", value: "差动调节" },
+];
+
+const INSTALL_OPTIONS = [
+  { value: "水平" },
+  { value: "垂直" },
+];
+
+export default function BasicInfo() {
+  return (
+    <>
+      <Row gutter={16}>
+        <Col xs={24} md={12}>
+          <Form.Item label="涂布工艺名称" name="processName" rules={[{ required: true, message: "请选择涂布工艺" }]}> 
+            <Select options={PROCESS_OPTIONS} />
+          </Form.Item>
+        </Col>
+        <Col xs={24} md={12}>
+          <Form.Item label="涂布液名称" name="liquidName" rules={[{ required: true, message: "请输入涂布液名称" }]}> 
+            <Input />
+          </Form.Item>
+        </Col>
+        <Col xs={12} md={6}>
+          <Form.Item label="涂布层数" name="layerCount" initialValue={1}> 
+            <InputNumber min={1} style={{ width: "100%" }} />
+          </Form.Item>
+        </Col>
+        <Col xs={12} md={6}>
+          <IntervalInputFormItem label="模头有效涂布宽度" name="effectiveWidth" unit="mm" />
+        </Col>
+        <Col xs={12} md={6}>
+          <Form.Item label="模唇微调方式" name="microAdjust" rules={[{ required: true, message: "请选择方式" }]}> 
+            <Radio.Group options={MICRO_ADJUST} optionType="button" />
+          </Form.Item>
+        </Col>
+        <Col xs={12} md={6}>
+          <Form.Item label="涂布模头安装方式" name="installMethod"> 
+            <AutoComplete options={INSTALL_OPTIONS} />
+          </Form.Item>
+        </Col>
+        <Col xs={24} md={12}>
+          <Form.Item label="涂布模头安装孔位置" name="installHole"> 
+            <Input />
+          </Form.Item>
+        </Col>
+      </Row>
+    </>
+  );
+}

--- a/src/components/quoteForm/CoatingDieForm/CoatingDieForm.tsx
+++ b/src/components/quoteForm/CoatingDieForm/CoatingDieForm.tsx
@@ -1,0 +1,30 @@
+import { forwardRef, useImperativeHandle } from "react";
+import { Form, FormInstance } from "antd";
+import ProForm from "@ant-design/pro-form";
+import BasicInfo from "./BasicInfo";
+import LiquidInfo from "./LiquidInfo";
+import ProcessInfo from "./ProcessInfo";
+
+export interface CoatingDieFormRef {
+  form: FormInstance;
+}
+
+const CoatingDieForm = forwardRef<CoatingDieFormRef, { quoteId: number; quoteItemId: number; readOnly?: boolean }>(
+  ({ readOnly = false }, ref) => {
+    const [form] = Form.useForm();
+
+    useImperativeHandle(ref, () => ({
+      form,
+    }));
+
+    return (
+      <ProForm layout="vertical" form={form} submitter={false} disabled={readOnly}>
+        <BasicInfo />
+        <LiquidInfo />
+        <ProcessInfo />
+      </ProForm>
+    );
+  }
+);
+
+export default CoatingDieForm;

--- a/src/components/quoteForm/CoatingDieForm/LiquidInfo.tsx
+++ b/src/components/quoteForm/CoatingDieForm/LiquidInfo.tsx
@@ -1,0 +1,79 @@
+import { Col, Form, Input, InputNumber, Radio, Row, Select, Segmented } from "antd";
+import { IntervalInputFormItem } from "@/components/general/IntervalInput";
+
+const LIQUID_PROPERTIES = ["腐蚀性", "磨蚀性", "毒性", "粘性", "易结晶", "易沉淀"].map(v => ({label:v,value:v}));
+const LIQUID_FEATURES = ["水状", "蜂蜜状", "乳胶状", "砂浆状", "粘土浆状"].map(v=>({label:v,value:v}));
+
+export default function LiquidInfo() {
+  return (
+    <>
+      <Row gutter={16}>
+        <Col xs={24} md={12}>
+          <Form.Item label="涂布液体类型和化学元素" name="liquidType">
+            <Input />
+          </Form.Item>
+        </Col>
+        <Col xs={24} md={12}>
+          <Form.Item label="涂布液特性" name="liquidProperty">
+            <Select mode="tags" options={LIQUID_PROPERTIES} />
+          </Form.Item>
+        </Col>
+        <Col xs={24} md={12}>
+          <Form.Item label="涂布液特征" name="liquidFeature">
+            <Select mode="tags" options={LIQUID_FEATURES} />
+          </Form.Item>
+        </Col>
+        <Col xs={12} md={6}>
+          <Form.Item label="涂布液体ph值" name="liquidPh">
+            <InputNumber min={0} max={14} step={0.1} style={{ width: "100%" }} />
+          </Form.Item>
+        </Col>
+        <Col xs={12} md={6}>
+          <IntervalInputFormItem label="涂布液密度" name="liquidDensity" unit="g/cm³" />
+        </Col>
+        <Col xs={12} md={6}>
+          <Form.Item label="涂布液性质" name="liquidNature">
+            <Segmented options={["牛顿流体", "非牛顿流体"]} />
+          </Form.Item>
+        </Col>
+        <Col xs={12} md={6}>
+          <IntervalInputFormItem label="涂布液正常粘度范围" name="liquidViscosity" unit="cps" />
+        </Col>
+        <Col xs={12} md={6}>
+          <IntervalInputFormItem label="工艺温度" name="processTemp" initialValue={{ value: "15~25", front: 15, rear: 25, unit: "℃" }} unit="℃" />
+        </Col>
+        <Col xs={12} md={6}>
+          <Form.Item label="热电偶孔" name="thermocouple" initialValue={"有"}>
+            <Radio.Group>
+              <Radio value="有">有</Radio>
+              <Radio value="无">无</Radio>
+            </Radio.Group>
+          </Form.Item>
+        </Col>
+        <Col xs={12} md={6}>
+          <IntervalInputFormItem label="线速度" name="lineSpeed" unit="mm/s" />
+        </Col>
+        <Col xs={12} md={6}>
+          <IntervalInputFormItem label="固含量" name="solidContent" unit="%" />
+        </Col>
+        <Col xs={12} md={6}>
+          <Form.Item label="是否存在颗粒" name="hasParticle" initialValue="无">
+            <Radio.Group>
+              <Radio value="有">有</Radio>
+              <Radio value="无">无</Radio>
+            </Radio.Group>
+          </Form.Item>
+        </Col>
+        <Form.Item noStyle dependencies={["hasParticle"]}>
+          {({ getFieldValue }) => {
+            return getFieldValue("hasParticle") === "有" ? (
+              <Col xs={12} md={6}>
+                <IntervalInputFormItem label="颗粒大小" name="particleSize" unit="μm" />
+              </Col>
+            ) : null;
+          }}
+        </Form.Item>
+      </Row>
+    </>
+  );
+}

--- a/src/components/quoteForm/CoatingDieForm/ProcessInfo.tsx
+++ b/src/components/quoteForm/CoatingDieForm/ProcessInfo.tsx
@@ -1,0 +1,108 @@
+import { Col, Form, Input, InputNumber, Radio, Row, AutoComplete, Select } from "antd";
+import TextArea from "antd/es/input/TextArea";
+import { IntervalInputFormItem } from "@/components/general/IntervalInput";
+import MaterialSelect from "@/components/general/MaterialSelect";
+
+const YIELD_UNITS = ["kg/h", "ml/min"].map(v => ({label:v,value:v}));
+
+export default function ProcessInfo() {
+  return (
+    <>
+      <Row gutter={16}>
+        <Col xs={12} md={6}>
+          <IntervalInputFormItem label="湿膜厚度" name="wetThickness" unit="μm" />
+        </Col>
+        <Col xs={12} md={6}>
+          <IntervalInputFormItem label="干膜厚度" name="dryThickness" unit="nm" />
+        </Col>
+        <Col xs={12} md={6}>
+          <Form.Item label="干膜厚度偏差" name="dryDeviation" initialValue="＜5%">
+            <Input />
+          </Form.Item>
+        </Col>
+        <Col xs={12} md={6}>
+          <IntervalInputFormItem label="涂布产量" name="yield" units={YIELD_UNITS.map(u=>u.value)} />
+        </Col>
+        <Col xs={12} md={6}>
+          <Form.Item label="基材类型" name="substrateType" initialValue="玻璃">
+            <Select options={[{label:"玻璃",value:"玻璃"}]} />
+          </Form.Item>
+        </Col>
+        <Col xs={12} md={6}>
+          <IntervalInputFormItem label="基材宽度" name="substrateWidth" unit="mm" />
+        </Col>
+        <Col xs={12} md={6}>
+          <IntervalInputFormItem label="基材厚度" name="substrateThickness" unit="μm" />
+        </Col>
+        <Col xs={24} md={12}>
+          <Form.Item label="流体的控制方法" name="controlMethod">
+            <Input />
+          </Form.Item>
+        </Col>
+        <Col xs={12} md={6}>
+          <IntervalInputFormItem label="泵后压力" name="pumpPressure" unit="Mpa" />
+        </Col>
+        <Col xs={12} md={6}>
+          <Form.Item label="模头垫片" name="needShim" initialValue="不需要">
+            <Radio.Group>
+              <Radio value="需要">需要</Radio>
+              <Radio value="不需要">不需要</Radio>
+            </Radio.Group>
+          </Form.Item>
+        </Col>
+        <Form.Item noStyle dependencies={["needShim"]}>
+          {({ getFieldValue }) =>
+            getFieldValue("needShim") === "需要" ? (
+              <>
+                <Col xs={12} md={6}>
+                  <Form.Item label="垫片材质" name="shimMaterial">
+                    <MaterialSelect />
+                  </Form.Item>
+                </Col>
+                <Col xs={12} md={6}>
+                  <Form.Item label="垫片规格及厚度" name="shimSpec">
+                    <Input />
+                  </Form.Item>
+                </Col>
+              </>
+            ) : null
+          }
+        </Form.Item>
+        <Col xs={24} md={12}>
+          <Form.Item label="模头主体材料" name="bodyMaterial">
+            <MaterialSelect />
+          </Form.Item>
+        </Col>
+        <Col xs={24} md={12}>
+          <Form.Item label="紧固件(螺丝)" name="fastener" initialValue="不锈钢螺丝">
+            <AutoComplete options={[{ value: "不锈钢螺丝" }]} />
+          </Form.Item>
+        </Col>
+        <Col xs={12} md={6}>
+          <Form.Item label="模唇直线度" name="lipStraightness">
+            <InputNumber
+              style={{ width: "100%" }}
+              formatter={(v) => (v ? `≤${v}μm` : "")}
+              parser={(v) => v?.replace(/≤|μm/g, "") as any}
+            />
+          </Form.Item>
+        </Col>
+        <Col xs={24} md={12}>
+          <Form.Item label="抛光精度要求" name="polish" initialValue="腔体及流面粗糙度：Ra<0.025." >
+            <AutoComplete options={[{ value: "供方设计" }, { value: "需方提供尺寸" }]} />
+          </Form.Item>
+        </Col>
+        <Col xs={24} md={12}>
+          <Form.Item label="进料口尺寸" name="feedSize">
+            <AutoComplete options={[{ value: "供方设计" }, { value: "需方提供尺寸" }]} />
+          </Form.Item>
+        </Col>
+        <Col xs={24}>
+          <Form.Item label="特殊要求" name="special">
+            <TextArea rows={3} />
+          </Form.Item>
+        </Col>
+      </Row>
+    </>
+  );
+}

--- a/src/components/template/TemplateCreate.tsx
+++ b/src/components/template/TemplateCreate.tsx
@@ -40,6 +40,7 @@ const FORM_TYPE_OPTIONS = [
   { label: "过滤器", value: "FilterForm" },
   { label: "测厚仪", value: "ThicknessGaugeForm" },
   { label: "液压站", value: "HydraulicStationForm" },
+  { label: "涂布模头", value: "CoatingDieForm" },
   { label: "物料", value: "PartsForm" },
   { label: "其他", value: "OtherForm" },
 ];

--- a/src/components/template/TemplateTable.tsx
+++ b/src/components/template/TemplateTable.tsx
@@ -24,6 +24,7 @@ const TEMPLATE_TYPE_MAP: Record<string, string> = {
   FilterForm: "过滤器",
   ThicknessGaugeForm: "测厚仪",
   HydraulicStationForm: "液压站",
+  CoatingDieForm: "涂布模头",
   PartsForm: "小配件",
   OtherForm: "其他",
 };


### PR DESCRIPTION
## Summary
- implement CoatingDieForm with BasicInfo, LiquidInfo and ProcessInfo sections
- wire up new CoatingDieForm in template creation and product form selector
- update template table and form type options

## Testing
- `npm install` *(fails: registry domain blocked)*
- `npm run lint` *(fails: missing dependencies due to failed install)*

------
https://chatgpt.com/codex/tasks/task_e_686686efada08327a7066c5cfc3ba4ef