### PR TITLE
Refactor quote share popover

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import HistoryQuoteTablePage from "./page/quote/HistoryQuoteTablePage";
 import OAQuoteTablePage from "./page/quote/OAQuoteTablePage";
 import TodoQuoteTablePage from "./page/quote/TodoQuoteTablePage";
 import QuoteFormPage from "./page/quote/QuoteFormPage";
+import QuoteSharePage from "./page/quote/QuoteSharePage";
 import TemplateListPage from "./page/template/TemplateListPage";
 import { NoPermissionPage } from "./page/NoPermissionPage";
 
@@ -53,6 +54,7 @@ const App: React.FC = () => {
 
           {/* 不需要鉴权的路由 */}
           <Route path="/auth-callback" element={<AuthCallback />} />
+          <Route path="/quote/share/:uuid" element={<QuoteSharePage />} />
           <Route path="/login" element={<div />} />
           <Route path="/error/no-permission" element={<NoPermissionPage />} />
 

--- a/src/api/services/quote.service.ts
+++ b/src/api/services/quote.service.ts
@@ -100,4 +100,59 @@ export const QuoteService = {
     });
     return res.data as Blob;
   },
+
+  async createShareLink(
+    quoteItemId: number,
+    expiresIn: number,
+    editable = false
+  ) {
+    const res = await apiClient.post("/quoteItem/share", {
+      quoteItemId,
+      expiresIn,
+      editable,
+    });
+    return res.data as { uuid: string };
+  },
+
+  async getShare(uuid: string) {
+    const res = await apiClient.get("/quoteItem/share/detail", {
+      params: { uuid },
+    });
+    return res.data as {
+      quoteItem: QuoteItem;
+      quoteId: number;
+      editable: boolean;
+      shareUserId: string;
+      shareUserName: string;
+    };
+  },
+
+  async getShareLinks(quoteItemId: number) {
+    const res = await apiClient.get("/quoteItem/share", {
+      params: { quoteItemId },
+    });
+    return res.data as
+      | undefined
+      | { viewUuid: string; editUuid: string; expireDays?: number };
+  },
+
+  async disableShare(quoteItemId: number) {
+    const res = await apiClient.post("/quoteItem/share/disable", {
+      quoteItemId,
+    });
+    return res.data;
+  },
+
+  async saveShare(
+    uuid: string,
+    shareUserId: string,
+    quoteItem: Partial<QuoteItem>
+  ) {
+    const res = await apiClient.post("/quoteItem/share/save", {
+      uuid,
+      shareUserId,
+      quoteItem,
+    });
+    return res.data;
+  },
 };

--- a/src/components/quote/ProductConfigForm/ProductConfigModal.tsx
+++ b/src/components/quote/ProductConfigForm/ProductConfigModal.tsx
@@ -6,6 +6,7 @@ import ProductConfigurationForm from "./ProductConfigurationForm";
 import { CheckOutlined, EditOutlined } from "@ant-design/icons";
 import { QuoteItem } from "@/types/types";
 import ImportProductModal from "./ImportProductModal";
+import QuoteSharePopover from "../Share/QuoteSharePopover";
 
 interface ProductConfigModalProps {
   open: boolean;
@@ -156,13 +157,16 @@ const ProductConfigModal: React.FC<ProductConfigModalProps> = ({
               {quoteItem?.importInfo &&
                 `(${quoteItem.importInfo.id} ${quoteItem.importInfo.name})`}
             </span>
-            <Button
-              type="link"
-              onClick={() => setImportOpen(true)}
-              disabled={quoteItem?.formType === "OtherForm"}
-            >
-              从模版导入
-            </Button>
+            <div>
+              <QuoteSharePopover quoteItem={quoteItem} />
+              <Button
+                type="link"
+                onClick={() => setImportOpen(true)}
+                disabled={quoteItem?.formType === "OtherForm"}
+              >
+                从模版导入
+              </Button>
+            </div>
           </div>
         }
         width={800}

--- a/src/components/quote/Share/QuoteSharePopover.tsx
+++ b/src/components/quote/Share/QuoteSharePopover.tsx
@@ -1,0 +1,126 @@
+import React, { useEffect, useState } from "react";
+import { Popover, Button, Switch, Input, Space, DatePicker } from "antd";
+import dayjs, { Dayjs } from "dayjs";
+import { ShareAltOutlined } from "@ant-design/icons";
+import { QuoteItem } from "@/types/types";
+import { QuoteService } from "@/api/services/quote.service";
+
+interface QuoteSharePopoverProps {
+  quoteItem?: QuoteItem;
+}
+
+const QuoteSharePopover: React.FC<QuoteSharePopoverProps> = ({ quoteItem }) => {
+  const [visible, setVisible] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [enabled, setEnabled] = useState(false);
+  const [expireDate, setExpireDate] = useState<Dayjs>(dayjs().add(1, "day"));
+  const [viewLink, setViewLink] = useState("");
+  const [editLink, setEditLink] = useState("");
+
+  const base = typeof window !== "undefined" ? window.location.origin : "";
+
+  const refreshLinks = async (date: Dayjs) => {
+    const days = date.startOf("day").diff(dayjs().startOf("day"), "day");
+    if (!quoteItem) return;
+    setLoading(true);
+    try {
+      const view = await QuoteService.createShareLink(quoteItem.id, days, false);
+      const edit = await QuoteService.createShareLink(quoteItem.id, days, true);
+      setViewLink(`${base}/quote/share/${view.uuid}`);
+      setEditLink(`${base}/quote/share/${edit.uuid}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const disableShare = async () => {
+    if (!quoteItem) return;
+    setLoading(true);
+    try {
+      await QuoteService.disableShare(quoteItem.id);
+    } finally {
+      setViewLink("");
+      setEditLink("");
+      setLoading(false);
+    }
+  };
+
+  const loadShareInfo = async () => {
+    if (!quoteItem) return;
+    setLoading(true);
+    try {
+      const info = await QuoteService.getShareLinks(quoteItem.id);
+      if (info) {
+        setEnabled(true);
+        setViewLink(`${base}/quote/share/${info.viewUuid}`);
+        setEditLink(`${base}/quote/share/${info.editUuid}`);
+        if (info.expireDays)
+          setExpireDate(dayjs().add(info.expireDays, "day"));
+      } else {
+        setEnabled(false);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSwitch = async (checked: boolean) => {
+    if (checked) {
+      await refreshLinks(expireDate);
+    } else {
+      await disableShare();
+    }
+    setEnabled(checked);
+  };
+
+  useEffect(() => {
+    if (visible) {
+      loadShareInfo();
+    }
+  }, [visible]);
+
+  useEffect(() => {
+    if (enabled && visible) {
+      refreshLinks(expireDate);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expireDate]);
+
+  const content = (
+    <Space direction="vertical">
+      <div>
+        <Switch checked={enabled} onChange={handleSwitch} loading={loading} /> 分享
+      </div>
+      {enabled && (
+        <>
+          <DatePicker
+            value={expireDate}
+            onChange={(d) => d && setExpireDate(d)}
+            disabledDate={(current) => {
+              const diff = current
+                ? current.startOf("day").diff(dayjs().startOf("day"), "day")
+                : 0;
+              return diff < 1 || diff > 3;
+            }}
+          />
+          <Input readOnly value={viewLink} addonBefore="查看" />
+          <Input readOnly value={editLink} addonBefore="编辑" />
+        </>
+      )}
+    </Space>
+  );
+
+  return (
+    <Popover
+      content={content}
+      trigger="click"
+      open={visible}
+      onOpenChange={setVisible}
+    >
+      <Button type="link" icon={<ShareAltOutlined />} />
+    </Popover>
+  );
+};
+
+export default QuoteSharePopover;
+

--- a/src/page/quote/QuoteSharePage.tsx
+++ b/src/page/quote/QuoteSharePage.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState, useRef } from "react";
+import { useParams } from "react-router-dom";
+import { Spin, Button, Watermark } from "antd";
+import ProductConfigurationForm from "@/components/quote/ProductConfigForm/ProductConfigurationForm";
+import { QuoteItem } from "@/types/types";
+import { QuoteService } from "@/api/services/quote.service";
+
+const QuoteSharePage: React.FC = () => {
+  const { uuid } = useParams<{ uuid: string }>();
+  const [data, setData] = useState<{
+    quoteItem?: QuoteItem;
+    quoteId?: number;
+    editable?: boolean;
+    shareUserId?: string;
+    shareUserName?: string;
+  }>();
+  const formRef = useRef<{ modelForm?: any }>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!uuid) return;
+      try {
+        const res = await QuoteService.getShare(uuid);
+        setData(res);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    load();
+  }, [uuid]);
+
+  if (!data) return <Spin />;
+
+  const handleSave = async (config: any) => {
+    if (!uuid || !data.shareUserId || !config) return;
+    try {
+      await QuoteService.saveShare(uuid, data.shareUserId, { config });
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const content = (
+    <ProductConfigurationForm
+      ref={formRef}
+      quoteId={data.quoteId ?? 0}
+      quoteItem={data.quoteItem}
+      readOnly={!data.editable}
+      showPrice={false}
+    />
+  );
+
+  return (
+    <Watermark content={`${data.shareUserName} (${data.shareUserId})`}>
+      <div style={{ position: "relative" }}>
+        {content}
+        {data.editable && (
+          <Button
+            type="primary"
+            onClick={() =>
+              handleSave(formRef.current?.modelForm?.getFieldsValue())
+            }
+          >
+            保存
+          </Button>
+        )}
+      </div>
+    </Watermark>
+  );
+};
+
+export default QuoteSharePage;


### PR DESCRIPTION
## Summary
- update quote share API helpers for additional info
- switch share popover to DatePicker restricted to 3 days
- make shared quote page editable depending on link
- add watermark and save button with share details
- apply antd Watermark to shared quote page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686688509e948327b823222fcf66ae15