### PR TITLE
Update share popover expiration handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import HistoryQuoteTablePage from "./page/quote/HistoryQuoteTablePage";
 import OAQuoteTablePage from "./page/quote/OAQuoteTablePage";
 import TodoQuoteTablePage from "./page/quote/TodoQuoteTablePage";
 import QuoteFormPage from "./page/quote/QuoteFormPage";
+import QuoteSharePage from "./page/quote/QuoteSharePage";
 import TemplateListPage from "./page/template/TemplateListPage";
 import { NoPermissionPage } from "./page/NoPermissionPage";
 
@@ -53,6 +54,7 @@ const App: React.FC = () => {
 
           {/* 不需要鉴权的路由 */}
           <Route path="/auth-callback" element={<AuthCallback />} />
+          <Route path="/quote/share/:uuid" element={<QuoteSharePage />} />
           <Route path="/login" element={<div />} />
           <Route path="/error/no-permission" element={<NoPermissionPage />} />
 

--- a/src/api/services/quote.service.ts
+++ b/src/api/services/quote.service.ts
@@ -100,4 +100,73 @@ export const QuoteService = {
     });
     return res.data as Blob;
   },
+
+  async createShareLink(
+    quoteItemId: number,
+    expiresAt: Date,
+    editable = false
+  ) {
+    const res = await apiClient.post("/quoteItem/share", {
+      quoteItemId,
+      expiresAt,
+      editable,
+    });
+    return res.data as { uuid: string; pwd: string };
+  },
+
+  async getShare(uuid: string, pwd: string) {
+    const res = await apiClient.get("/quoteItem/share/detail", {
+      params: { uuid, pwd },
+    });
+    return res.data as {
+      quoteItem: QuoteItem;
+      quoteId: number;
+      editable: boolean;
+      shareUserId: string;
+      shareUserName: string;
+    };
+  },
+
+  async getShareLinks(quoteItemId: number) {
+    const res = await apiClient.get("/quoteItem/share", {
+      params: { quoteItemId },
+    });
+    return res.data as
+      | undefined
+      | {
+          viewUuid: string;
+          viewPwd: string;
+          editUuid: string;
+          editPwd: string;
+          expiresAt?: string;
+        };
+  },
+
+  async disableShare(quoteItemId: number) {
+    const res = await apiClient.post("/quoteItem/share/disable", {
+      quoteItemId,
+    });
+    return res.data;
+  },
+
+  async updateExpire(uuid: string, expiresAt: Date) {
+    const res = await apiClient.post("/quoteItem/share/update", {
+      uuid,
+      expiresAt,
+    });
+    return res.data;
+  },
+
+  async saveShare(
+    uuid: string,
+    shareUserId: string,
+    quoteItem: Partial<QuoteItem>
+  ) {
+    const res = await apiClient.post("/quoteItem/share/save", {
+      uuid,
+      shareUserId,
+      quoteItem,
+    });
+    return res.data;
+  },
 };

--- a/src/components/quote/ProductConfigForm/ProductConfigModal.tsx
+++ b/src/components/quote/ProductConfigForm/ProductConfigModal.tsx
@@ -6,6 +6,7 @@ import ProductConfigurationForm from "./ProductConfigurationForm";
 import { CheckOutlined, EditOutlined } from "@ant-design/icons";
 import { QuoteItem } from "@/types/types";
 import ImportProductModal from "./ImportProductModal";
+import QuoteSharePopover from "../Share/QuoteSharePopover";
 
 interface ProductConfigModalProps {
   open: boolean;
@@ -156,13 +157,16 @@ const ProductConfigModal: React.FC<ProductConfigModalProps> = ({
               {quoteItem?.importInfo &&
                 `(${quoteItem.importInfo.id} ${quoteItem.importInfo.name})`}
             </span>
-            <Button
-              type="link"
-              onClick={() => setImportOpen(true)}
-              disabled={quoteItem?.formType === "OtherForm"}
-            >
-              从模版导入
-            </Button>
+            <div>
+              <QuoteSharePopover quoteItem={quoteItem} quoteId={quoteId} />
+              <Button
+                type="link"
+                onClick={() => setImportOpen(true)}
+                disabled={quoteItem?.formType === "OtherForm"}
+              >
+                从模版导入
+              </Button>
+            </div>
           </div>
         }
         width={800}

--- a/src/components/quote/Share/QuoteSharePopover.tsx
+++ b/src/components/quote/Share/QuoteSharePopover.tsx
@@ -1,0 +1,212 @@
+import React, { useEffect, useState } from "react";
+import {
+  Popover,
+  Button,
+  Switch,
+  Space,
+  DatePicker,
+  message,
+} from "antd";
+import InputWithButton from "@/components/general/InputWithButton";
+import { useAuthStore } from "@/store/useAuthStore";
+import { useQuoteStore } from "@/store/useQuoteStore";
+import dayjs, { Dayjs } from "dayjs";
+import { ShareAltOutlined } from "@ant-design/icons";
+import { QuoteItem } from "@/types/types";
+import { QuoteService } from "@/api/services/quote.service";
+
+interface QuoteSharePopoverProps {
+  quoteItem?: QuoteItem;
+  quoteId?: number;
+}
+
+const QuoteSharePopover: React.FC<QuoteSharePopoverProps> = ({
+  quoteItem,
+  quoteId,
+}) => {
+  const [visible, setVisible] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [enabled, setEnabled] = useState(false);
+  const [expireDate, setExpireDate] = useState<Dayjs>(dayjs().add(1, "day"));
+  const [viewLink, setViewLink] = useState("");
+  const [editLink, setEditLink] = useState("");
+  const [viewUuid, setViewUuid] = useState("");
+  const [editUuid, setEditUuid] = useState("");
+  const [isExpired, setIsExpired] = useState(false);
+
+  const shareUserName = useAuthStore((s) => s.name) || "";
+  const customerName = useQuoteStore(
+    (s) => s.quotes.find((q) => q.id === quoteId)?.customerName
+  ) || "";
+  const productName = quoteItem?.productName || "";
+
+  const base = typeof window !== "undefined" ? window.location.origin : "";
+
+  const refreshLinks = async (date: Dayjs) => {
+    if (!quoteItem) return;
+    setLoading(true);
+    try {
+      const view = await QuoteService.createShareLink(
+        quoteItem.id,
+        date.toDate(),
+        false
+      );
+      const edit = await QuoteService.createShareLink(
+        quoteItem.id,
+        date.toDate(),
+        true
+      );
+      setViewLink(`${base}/quote/share/${view.uuid}?pwd=${view.pwd}`);
+      setEditLink(`${base}/quote/share/${edit.uuid}?pwd=${edit.pwd}`);
+      setViewUuid(view.uuid);
+      setEditUuid(edit.uuid);
+      setIsExpired(date.isBefore(dayjs(), "day"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const disableShare = async () => {
+    if (!quoteItem) return;
+    setLoading(true);
+    try {
+      await QuoteService.disableShare(quoteItem.id);
+    } finally {
+      setViewLink("");
+      setEditLink("");
+      setViewUuid("");
+      setEditUuid("");
+      setIsExpired(false);
+      setLoading(false);
+    }
+  };
+
+  const loadShareInfo = async () => {
+    if (!quoteItem) return;
+    setLoading(true);
+    try {
+      const info = await QuoteService.getShareLinks(quoteItem.id);
+      if (info) {
+        setEnabled(true);
+        setViewLink(`${base}/quote/share/${info.viewUuid}?pwd=${info.viewPwd}`);
+        setEditLink(`${base}/quote/share/${info.editUuid}?pwd=${info.editPwd}`);
+        setViewUuid(info.viewUuid);
+        setEditUuid(info.editUuid);
+        if (info.expiresAt) {
+          const date = dayjs(info.expiresAt);
+          setExpireDate(date);
+          setIsExpired(date.isBefore(dayjs(), "day"));
+        }
+      } else {
+        setEnabled(false);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSwitch = async (checked: boolean) => {
+    if (checked) {
+      await refreshLinks(expireDate);
+    } else {
+      await disableShare();
+    }
+    setEnabled(checked);
+    setIsExpired(false);
+  };
+
+  const handleUpdateExpire = async () => {
+    if (!viewUuid || !editUuid) return;
+    setLoading(true);
+    try {
+      await QuoteService.updateExpire(viewUuid, expireDate.toDate());
+      await QuoteService.updateExpire(editUuid, expireDate.toDate());
+      setIsExpired(expireDate.isBefore(dayjs(), "day"));
+      message.success("已更新");
+    } catch (e) {
+      message.error("更新失败");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCopy = (editable: boolean) => {
+    const link = editable ? editLink : viewLink;
+    const typeLabel = editable ? "（可编辑）" : "（仅浏览）";
+    const text = `${shareUserName}向你分享了${customerName}的${productName}${typeLabel}点击以下链接${link}`;
+    navigator.clipboard
+      .writeText(text)
+      .then(() => message.success("已复制"))
+      .catch(() => message.error("复制失败"));
+  };
+
+  useEffect(() => {
+    if (visible) {
+      loadShareInfo();
+    }
+  }, [visible]);
+
+
+  const content = (
+    <Space direction="vertical">
+      <div>
+        <Switch
+          checked={enabled}
+          onChange={handleSwitch}
+          loading={loading}
+          style={isExpired ? { backgroundColor: "red" } : {}}
+        />
+        分享 {isExpired && <span style={{ color: "red" }}>已过期</span>}
+      </div>
+      {enabled && (
+        <>
+          <Space>
+            <DatePicker
+              value={expireDate}
+              onChange={(d) => d && setExpireDate(d)}
+              disabledDate={(current) => {
+                const diff = current
+                  ? current.startOf("day").diff(dayjs().startOf("day"), "day")
+                  : 0;
+                return diff < 1 || diff > 3;
+              }}
+            />
+            <Button type="primary" size="small" onClick={handleUpdateExpire}
+              loading={loading}
+            >
+              确认
+            </Button>
+          </Space>
+          <InputWithButton
+            readOnly
+            value={viewLink}
+            addonBefore="查看"
+            buttonText="复制"
+            onButtonClick={() => handleCopy(false)}
+          />
+          <InputWithButton
+            readOnly
+            value={editLink}
+            addonBefore="编辑"
+            buttonText="复制"
+            onButtonClick={() => handleCopy(true)}
+          />
+        </>
+      )}
+    </Space>
+  );
+
+  return (
+    <Popover
+      content={content}
+      trigger="click"
+      open={visible}
+      onOpenChange={setVisible}
+    >
+      <Button type="link" icon={<ShareAltOutlined />} />
+    </Popover>
+  );
+};
+
+export default QuoteSharePopover;
+

--- a/src/page/quote/QuoteSharePage.tsx
+++ b/src/page/quote/QuoteSharePage.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState, useRef } from "react";
+import { useParams, useSearchParams } from "react-router-dom";
+import { Spin, Button, Watermark } from "antd";
+import ProductConfigurationForm from "@/components/quote/ProductConfigForm/ProductConfigurationForm";
+import { QuoteItem } from "@/types/types";
+import { QuoteService } from "@/api/services/quote.service";
+
+const QuoteSharePage: React.FC = () => {
+  const { uuid } = useParams<{ uuid: string }>();
+  const [search] = useSearchParams();
+  const pwd = search.get("pwd") ?? "";
+  const [data, setData] = useState<{
+    quoteItem?: QuoteItem;
+    quoteId?: number;
+    editable?: boolean;
+    shareUserId?: string;
+    shareUserName?: string;
+  }>();
+  const formRef = useRef<{ modelForm?: any }>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!uuid) return;
+      try {
+        const res = await QuoteService.getShare(uuid, pwd);
+        setData(res);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    load();
+  }, [uuid, pwd]);
+
+  if (!data) return <Spin />;
+
+  const handleSave = async (config: any) => {
+    if (!uuid || !data.shareUserId || !config) return;
+    try {
+      await QuoteService.saveShare(uuid, data.shareUserId, { config });
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const content = (
+    <ProductConfigurationForm
+      ref={formRef}
+      quoteId={data.quoteId ?? 0}
+      quoteItem={data.quoteItem}
+      readOnly={!data.editable}
+      showPrice={false}
+    />
+  );
+
+  return (
+    <Watermark content={`${data.shareUserName} (${data.shareUserId})`}>
+      <div style={{ position: "relative" }}>
+        {content}
+        {data.editable && (
+          <Button
+            type="primary"
+            onClick={() =>
+              handleSave(formRef.current?.modelForm?.getFieldsValue())
+            }
+          >
+            保存
+          </Button>
+        )}
+      </div>
+    </Watermark>
+  );
+};
+
+export default QuoteSharePage;


### PR DESCRIPTION
## Summary
- add `updateExpire` API helper
- allow share popover to update expiration with confirm button
- show expired status with red switch and label

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: TS errors and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686688509e948327b823222fcf66ae15