### PR TITLE
Limit heating ring option

### DIFF
--- a/src/components/quoteForm/FilterForm/FilterForm.tsx
+++ b/src/components/quoteForm/FilterForm/FilterForm.tsx
@@ -202,7 +202,7 @@ const FilterForm = forwardRef(
             </Col>
             <Col xs={12} md={12}>
               <Form.Item label="机体加热方式" name="heatingMethod">
-                <HeatingMethodSelect multiple />
+                <HeatingMethodSelect multiple showHeatingRing />
               </Form.Item>
             </Col>
           </Row>

--- a/src/components/quoteForm/formComponents/HeatingMethodInput.tsx
+++ b/src/components/quoteForm/formComponents/HeatingMethodInput.tsx
@@ -17,6 +17,8 @@ interface HeatingMethodSelectProps {
   temperature?: string;
   multiple?: boolean;
   disabled?: boolean;
+  /** Whether to show the "加热圈" option */
+  showHeatingRing?: boolean;
   style?: React.CSSProperties;
   id?: string;
   className?: string;
@@ -31,6 +33,7 @@ export const HeatingMethodSelect: React.FC<HeatingMethodSelectProps> = ({
   temperature,
   multiple = false,
   disabled = false,
+  showHeatingRing = false,
   style,
   id,
   className,
@@ -86,7 +89,7 @@ export const HeatingMethodSelect: React.FC<HeatingMethodSelectProps> = ({
   const methodOptions = [
     { value: "油加温", label: "油加温" },
     { value: "加热棒", label: "加热棒" },
-    { value: "加热圈", label: "加热圈" },
+    ...(showHeatingRing ? [{ value: "加热圈", label: "加热圈" }] : []),
     {
       value: "铸铝加热板",
       label: "铸铝加热板",


### PR DESCRIPTION
## Summary
- allow showing heating ring option conditionally
- show heating ring only in FilterForm

## Testing
- `npm run lint` *(fails: cannot find module `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_68674848baa88327b1d13916a7f3e437