### PR TITLE
Update readonly handling

### DIFF
--- a/src/components/quoteForm/CoatingDieForm/CoatingDieForm.tsx
+++ b/src/components/quoteForm/CoatingDieForm/CoatingDieForm.tsx
@@ -18,7 +18,7 @@ const CoatingDieForm = forwardRef<CoatingDieFormRef, { quoteId: number; quoteIte
     }));
 
     return (
-      <ProForm layout="vertical" form={form} submitter={false} disabled={readOnly}>
+      <ProForm layout="vertical" form={form} submitter={false}>
         <BasicInfo />
         <LiquidInfo />
         <ProcessInfo />

--- a/src/components/quoteForm/FeedblockForm/FeedblockForm.tsx
+++ b/src/components/quoteForm/FeedblockForm/FeedblockForm.tsx
@@ -122,7 +122,6 @@ const FeedblockForm = forwardRef(
           form={form}
           submitter={false}
           onValuesChange={handleFieldsChange}
-          disabled={readOnly}
         >
           <Row gutter={16}>
             <Col xs={12} md={6}>

--- a/src/components/quoteForm/FilterForm/FilterForm.tsx
+++ b/src/components/quoteForm/FilterForm/FilterForm.tsx
@@ -156,7 +156,6 @@ const FilterForm = forwardRef(
         form={form}
         submitter={false}
         onValuesChange={handleFieldsChange}
-        disabled={readOnly}
       >
         <FilterSelection form={form} filters={filters} />
         <ProCard

--- a/src/components/quoteForm/HydraulicStationForm/HydraulicStationForm.tsx
+++ b/src/components/quoteForm/HydraulicStationForm/HydraulicStationForm.tsx
@@ -76,7 +76,6 @@ const HydraulicStationForm = forwardRef(
         layout="vertical"
         form={form}
         submitter={false}
-        disabled={readOnly}
         onValuesChange={handleFieldsChange}
       >
         {linkedName && (

--- a/src/components/quoteForm/ManifoldForm/ManifoldForm.tsx
+++ b/src/components/quoteForm/ManifoldForm/ManifoldForm.tsx
@@ -34,7 +34,6 @@ const ManifoldForm = forwardRef(
         layout="vertical"
         form={form}
         submitter={false}
-        disabled={readOnly}
       >
         <Row gutter={16}>
           <Col xs={12} md={6}>

--- a/src/components/quoteForm/MeteringPumpForm/MeteringPumpForm.tsx
+++ b/src/components/quoteForm/MeteringPumpForm/MeteringPumpForm.tsx
@@ -196,7 +196,6 @@ const MeteringPumpForm = forwardRef(
           form={form}
           submitter={false}
           onValuesChange={handleFieldsChange}
-          disabled={readOnly}
         >
           <ModelSelection temperatureRequired={quoteType !== "history"} />
           <ModelOption />

--- a/src/components/quoteForm/OtherForm.tsx
+++ b/src/components/quoteForm/OtherForm.tsx
@@ -18,7 +18,7 @@ export const OtherForm = forwardRef<
   // 计算小计``
 
   return (
-    <Form layout={"vertical"} form={form} disabled={readOnly}>
+    <Form layout={"vertical"} form={form}>
       <Form.Item
         name="remark"
         label="规格型号"

--- a/src/components/quoteForm/PriceForm.tsx
+++ b/src/components/quoteForm/PriceForm.tsx
@@ -61,7 +61,6 @@ const PriceForm = forwardRef<PriceFormRef, PriceFormProps>(
         // preserve={false}
         form={form}
         onValuesChange={handleValuesChange}
-        disabled={readOnly}
       >
         <Row gutter={20}>
           <Col xs={12} sm={12}>
@@ -74,8 +73,6 @@ const PriceForm = forwardRef<PriceFormRef, PriceFormProps>(
                 style={{ width: "100%" }}
                 buttonText="自动生成名称"
                 onButtonClick={handleGenerateName}
-                disabled={readOnly}
-                buttonProps={{ disabled: readOnly }}
               />
             </Form.Item>
           </Col>

--- a/src/components/quoteForm/SmartRegulator.tsx
+++ b/src/components/quoteForm/SmartRegulator.tsx
@@ -90,7 +90,6 @@ const SmartRegulator = forwardRef<
         form={form}
         submitter={false}
         onValuesChange={handleValuesChange}
-        disabled={readOnly}
       >
         <Row gutter={16}>
           <Col xs={12} md={8}>

--- a/src/components/quoteForm/ThicknessGaugeForm/ThicknessGaugeForm.tsx
+++ b/src/components/quoteForm/ThicknessGaugeForm/ThicknessGaugeForm.tsx
@@ -43,7 +43,6 @@ const ThicknessGaugeForm = forwardRef<
       form={form}
       submitter={false}
       onValuesChange={handleValuesChange}
-      disabled={readOnly}
     >
       <Row gutter={16}>
         <Col xs={12} md={6}>

--- a/src/components/quoteForm/dieForm/DieForm.tsx
+++ b/src/components/quoteForm/dieForm/DieForm.tsx
@@ -203,7 +203,7 @@ const DieForm = forwardRef(
           form={form}
           submitter={false}
           onValuesChange={handleFieldsChange}
-          disabled={readOnly || locked}
+          disabled={locked}
         >
           <SameProduct
             quoteId={quoteId}


### PR DESCRIPTION
## Summary
- avoid disabling forms when a quote item is readonly
- rely on ProductConfigurationForm overlay instead

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686747ee924483279f5fafa837dfea95