### PR TITLE
Add manifold form without link handling

### DIFF
--- a/src/components/quoteForm/ManifoldForm/ManifoldForm.tsx
+++ b/src/components/quoteForm/ManifoldForm/ManifoldForm.tsx
@@ -1,7 +1,26 @@
-import { Col, Form, FormInstance, InputNumber, Row, Select } from "antd";
+import {
+  Button,
+  Col,
+  Form,
+  FormInstance,
+  Input,
+  InputNumber,
+  Row,
+  Select,
+  Typography,
+} from "antd";
+import { ProCard } from "@ant-design/pro-components";
 import ProForm from "@ant-design/pro-form";
-import { forwardRef, useImperativeHandle } from "react";
-import RatioInput from "@/components/general/RatioInput";
+import { forwardRef, useImperativeHandle, useState } from "react";
+import { useQuoteStore } from "@/store/useQuoteStore";
+import ImportProductModal from "@/components/quote/ProductConfigForm/ImportProductModal";
+import MaterialSelect from "@/components/general/MaterialSelect";
+import AutoSlashInput from "@/components/general/AutoSlashInput";
+import ProFormListWrapper from "../formComponents/ProFormListWrapper";
+import { HeatingMethodSelect } from "../formComponents/HeatingMethodInput";
+import PowerFormItem from "../formComponents/PowerFormItem";
+import { CustomSelect } from "@/components/general/CustomSelect";
+import { MATERIAL_OPTIONS } from "@/util/MATERIAL";
 
 export interface ManifoldFormProps {
   quoteId?: number;
@@ -25,47 +44,197 @@ const ManifoldForm = forwardRef(
     ref
   ) => {
     const [form] = Form.useForm();
+    const [modalOpen, setModalOpen] = useState(false);
+
+    const quoteItems =
+      useQuoteStore.getState().quotes.find((q) => q.id === quoteId)?.items ?? [];
+    const findItemById = useQuoteStore.getState().findItemById;
+    const currentItem = findItemById(quoteItems, quoteItemId);
+    const linkedName = currentItem?.linkId
+      ? findItemById(quoteItems, currentItem.linkId)?.productName
+      : undefined;
+    const isLinked = !!currentItem?.linkId;
+
     useImperativeHandle(ref, () => ({
       form,
     }));
 
+    const handleImport = (item: any) => {
+      if (item?.config) {
+        const {
+          material,
+          temperature,
+          runnerNumber,
+          compositeStructure,
+          runnerLayers,
+        } = item.config as any;
+        form.setFieldsValue({
+          manualMaterial: material,
+          manualTemperature: temperature,
+          manualRunnerNumber: runnerNumber,
+          manualCompositeStructure: compositeStructure,
+          manualRunnerLayers: runnerLayers,
+        });
+      }
+      setModalOpen(false);
+    };
+
     return (
-      <ProForm
-        layout="vertical"
-        form={form}
-        submitter={false}
+      <ProCard
+        title="合流器配置"
+        collapsible
+        defaultCollapsed={false}
+        style={{ marginBottom: 16 }}
+        headerBordered
       >
-        <Row gutter={16}>
-          <Col xs={12} md={6}>
-            <Form.Item
-              label="加热分区"
-              name="heatingZone"
-              rules={[{ required: true, message: "请输入加热分区" }]}
-            >
-              <InputNumber min={0} style={{ width: "100%" }} />
-            </Form.Item>
-          </Col>
-          <Col xs={12} md={6}>
-            <Form.Item
-              label="复合比例"
-              name="compoundRatio"
-              initialValue="1:1:1"
-              rules={[{ required: true, message: "请输入复合比例" }]}
-            >
-              <RatioInput />
-            </Form.Item>
-          </Col>
-          <Col xs={12} md={6}>
-            <Form.Item
-              label="合流器图纸"
-              name="blueprint"
-              rules={[{ required: true, message: "请选择合流器图纸" }]}
-            >
-              <Select options={options} allowClear />
-            </Form.Item>
-          </Col>
-        </Row>
-      </ProForm>
+        <ProForm layout="vertical" form={form} submitter={false} preserve={false}>
+          {linkedName && (
+            <Typography.Text type="secondary" style={{ display: "block", marginBottom: 16 }}>
+              关联产品：{linkedName}
+            </Typography.Text>
+          )}
+          {isLinked ? (
+            <Row gutter={16}>
+              <Col xs={12} md={6}>
+                <Form.Item
+                  label="合流器加热分区"
+                  name="heatingZone"
+                  rules={[{ required: true, message: "请输入合流器加热分区" }]}
+                >
+                  <InputNumber min={0} style={{ width: "100%" }} />
+                </Form.Item>
+              </Col>
+              <Col xs={12} md={6}>
+                <Form.Item
+                  label="合流器图纸"
+                  name="blueprint"
+                  rules={[{ required: true, message: "请选择合流器图纸" }]}
+                >
+                  <Select options={options} allowClear />
+                </Form.Item>
+              </Col>
+            </Row>
+          ) : (
+            <>
+              <Row gutter={16} style={{ marginBottom: 16 }}>
+                <Col xs={24} md={12}>
+                  <Form.Item label="是否与模头互配" colon={false} style={{ marginBottom: 0 }}>
+                    <Button onClick={() => setModalOpen(true)}>选择模头编号</Button>
+                  </Form.Item>
+                </Col>
+              </Row>
+              <Row gutter={16}>
+                <Col xs={12} md={6}>
+                  <Form.Item
+                    label="合流器加热分区"
+                    name="heatingZone"
+                    rules={[{ required: true, message: "请输入合流器加热分区" }]}
+                  >
+                    <InputNumber min={0} style={{ width: "100%" }} />
+                  </Form.Item>
+                </Col>
+                <Col xs={12} md={6}>
+                  <Form.Item
+                    name="manualHeatingMethod"
+                    label="加热方式"
+                    rules={[{ required: true, message: "请选择加热方式" }]}
+                  >
+                    <HeatingMethodSelect multiple />
+                  </Form.Item>
+                </Col>
+                <PowerFormItem
+                  dependencyName="manualHeatingMethod"
+                  name="manualPower"
+                  label="加热电压"
+                />
+                <Col xs={12} md={6}>
+                  <Form.Item
+                    name="manualMaterial"
+                    label="塑料原料"
+                    rules={[{ required: true, message: "请选择原料" }]}
+                  >
+                    <MaterialSelect />
+                  </Form.Item>
+                </Col>
+                <Col xs={12} md={6}>
+                  <Form.Item
+                    name="manualTemperature"
+                    label="工艺温度"
+                    rules={[{ required: true, message: "请输入温度" }]}
+                  >
+                    <Input />
+                  </Form.Item>
+                </Col>
+                <Col xs={12} md={6}>
+                  <Form.Item
+                    name="manualRunnerNumber"
+                    label="共挤复合层数"
+                    rules={[{ required: true, message: "请输入层数" }]}
+                  >
+                    <InputNumber min={1} style={{ width: "100%" }} />
+                  </Form.Item>
+                </Col>
+                <Col xs={12} md={6}>
+                  <Form.Item
+                    name="manualCompositeStructure"
+                    label="层结构形式"
+                    rules={[{ required: true, message: "请输入结构形式" }]}
+                  >
+                    <AutoSlashInput />
+                  </Form.Item>
+                </Col>
+                <Col span={24}>
+                  <ProFormListWrapper
+                    name="manualRunnerLayers"
+                    label="每层复合比例"
+                    min={1}
+                    creatorButtonProps={{ creatorButtonText: "新增" }}
+                    formItems={
+                      <ProForm.Item
+                        name={[]}
+                        rules={[{ required: true, message: "请输入比例" }]}
+                      >
+                        <Input />
+                      </ProForm.Item>
+                    }
+                  />
+                </Col>
+                <Col xs={12} md={6}>
+                  <Form.Item
+                    name="manualDieMaterial"
+                    label="合流器材料"
+                    initialValue="3Cr13"
+                    rules={[{ required: true, message: "请选择材料" }]}
+                  >
+                    <CustomSelect initialGroups={MATERIAL_OPTIONS} />
+                  </Form.Item>
+                </Col>
+                <Col xs={12} md={6}>
+                  <Form.Item name="manualExtruder" label="挤出机分布">
+                    <Input />
+                  </Form.Item>
+                </Col>
+                <Col xs={12} md={6}>
+                  <Form.Item
+                    label="合流器图纸"
+                    name="blueprint"
+                    rules={[{ required: true, message: "请选择合流器图纸" }]}
+                  >
+                    <Select options={options} allowClear />
+                  </Form.Item>
+                </Col>
+              </Row>
+            </>
+          )}
+        </ProForm>
+        <ImportProductModal
+          open={modalOpen}
+          onCancel={() => setModalOpen(false)}
+          onImport={handleImport}
+          formType="DieForm"
+          orderOnly
+        />
+      </ProCard>
     );
   }
 );

--- a/src/components/quoteForm/dieForm/DieBody.tsx
+++ b/src/components/quoteForm/dieForm/DieBody.tsx
@@ -300,6 +300,19 @@ export const DieBody: React.FC<DieBodyProps> = ({ isHollow = false }) => {
             </Radio.Group>
           </Form.Item>
         </Col>
+        <Col xs={12} md={8}>
+          <Form.Item
+            name="hasManifold"
+            label="是否选配合流器"
+            rules={[{ required: true, message: "请选择是否选配合流器" }]}
+            initialValue={false}
+          >
+            <Radio.Group>
+              <Radio value={true}>是</Radio>
+              <Radio value={false}>否</Radio>
+            </Radio.Group>
+          </Form.Item>
+        </Col>
       </Row>
     </ProCard>
   );

--- a/src/components/quoteForm/dieForm/DieForm.tsx
+++ b/src/components/quoteForm/dieForm/DieForm.tsx
@@ -156,6 +156,19 @@ const DieForm = forwardRef(
       if (!result.result) form.setFieldValue("thicknessGauge", true);
     };
 
+    const handleHasManifold = async (value: boolean) => {
+      if (value) {
+        const result = await showProductActionModal(
+          addProp(["合流器"], "hasManifold", false)
+        );
+        if (!result.result) form.setFieldValue("hasManifold", false);
+        return;
+      }
+
+      const result = await showProductActionModal(deleteProp(["合流器"]));
+      if (!result.result) form.setFieldValue("hasManifold", true);
+    };
+
     const handleLowerLipStructure = (value: string) => {
       if (value?.includes("整体")) {
         form.setFieldValue("lipCount", 1);
@@ -187,6 +200,7 @@ const DieForm = forwardRef(
         smartRegulator: handleSmartRegulator,
         haveThermalInsulation: handleThermalInsulation,
         thicknessGauge: handleThicknessGauge,
+        hasManifold: handleHasManifold,
         lowerLipStructure: handleLowerLipStructure,
         lipCount: handleLipCount,
       };


### PR DESCRIPTION
## Summary
- simplify `ManifoldForm` logic
- show only heating zone and blueprint when linked
- allow manual manifold configuration with import button when not linked

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68689aa10ddc8327ae85080946407727