### PR TITLE
Add remark field to quote form

### DIFF
--- a/src/api/services/quote.service.ts
+++ b/src/api/services/quote.service.ts
@@ -16,6 +16,7 @@ export const QuoteService = {
     quoteName: string;
     contactName?: string;
     contactPhone?: string;
+    remark?: string;
     senderId?: string;
     senderPhone?: string;
     items?: Partial<QuoteItem>[];

--- a/src/components/quote/QuoteConfigTab.tsx
+++ b/src/components/quote/QuoteConfigTab.tsx
@@ -424,6 +424,21 @@ const QuoteConfigTab: React.FC<QuoteConfigTabProps> = ({
           </Col> */}
         </Row>
       </ProCard>
+      <ProCard
+        title="备注"
+        collapsible
+        defaultCollapsed={false}
+        style={{ marginBottom: 16 }}
+        headerBordered
+      >
+        <Row gutter={16}>
+          <Col span={24}>
+            <Form.Item name="remark" label="备注">
+              <Input.TextArea rows={3} placeholder="请输入备注信息" />
+            </Form.Item>
+          </Col>
+        </Row>
+      </ProCard>
     </>
   );
 };

--- a/src/store/useQuoteStore.ts
+++ b/src/store/useQuoteStore.ts
@@ -80,6 +80,7 @@ interface QuotesStore {
     quoteName: string;
     contactName?: string;
     contactPhone?: string;
+    remark?: string;
     senderId?: string;
     senderPhone?: string;
     items?: Partial<QuoteItem>[];

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -74,6 +74,7 @@ export interface Quote {
   senderPhone?: string; // 发送人电话
   telephone?: string; // 电话
   faxNumber?: string; // 传真号
+  remark?: string; // 备注
   companyInfo?: {
     companyAddress?: string; // 单位地址
     legalPersonName?: string; // 法定代表人


### PR DESCRIPTION
## Summary
- add `remark` field to quote type and quote API
- support remark field in quote store
- expose remark textarea in quote form

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686f533ba8ac8327a2a7bccb68f85a71