### PR TITLE
Implement dieForm updates

### DIFF
--- a/src/components/quoteForm/ManifoldForm/ManifoldForm.tsx
+++ b/src/components/quoteForm/ManifoldForm/ManifoldForm.tsx
@@ -51,6 +51,7 @@ const ManifoldForm = forwardRef(
   ) => {
     const [form] = Form.useForm();
     const [modalOpen, setModalOpen] = useState(false);
+    const [ratioUnit, setRatioUnit] = useState<string>(":");
     const a = useQuoteStore.getState().quotes;
     const quoteItems =
       useQuoteStore.getState().quotes.find((q) => q.id === quoteId)?.items ??
@@ -82,8 +83,24 @@ const ManifoldForm = forwardRef(
           compositeStructure: compositeStructure,
           runnerLayers: runnerLayers,
         });
+        if (runnerLayers && runnerLayers.length) {
+          const u = runnerLayers[0]?.ratio?.unit;
+          if (u) setRatioUnit(u);
+        }
       }
       setModalOpen(false);
+    };
+
+    const handleRatioUnitChange = (unit: string) => {
+      setRatioUnit(unit);
+      const list = (form.getFieldValue("runnerLayers") || []) as any[];
+      form.setFieldValue(
+        "runnerLayers",
+        list.map((item) => ({
+          ...item,
+          ratio: { ...(item.ratio || {}), unit },
+        }))
+      );
     };
 
     return (
@@ -220,8 +237,11 @@ const ManifoldForm = forwardRef(
                             materials={
                               Array.isArray(material) ? material : [material]
                             }
+                            ratioUnit={ratioUnit}
+                            onRatioUnitChange={handleRatioUnitChange}
                           />
                         }
+                        creatorRecord={{ ratio: { unit: ratioUnit } }}
                       />
                     )}
                   </ProFormDependency>

--- a/src/components/quoteForm/dieForm/Product.tsx
+++ b/src/components/quoteForm/dieForm/Product.tsx
@@ -20,6 +20,7 @@ import ProFormListWrapper from "../formComponents/ProFormListWrapper";
 
 import MaterialSelect from "@/components/general/MaterialSelect";
 import RunnerLayerItem from "../formComponents/RunnerLayerItem";
+import { useState } from "react";
 
 const RUNNER_TYPE_OPTIONS = [
   {
@@ -48,6 +49,19 @@ const EXTRUDE_TYPE_OPTIONS = [
 ];
 export const Product = () => {
   const form = Form.useFormInstance();
+  const [ratioUnit, setRatioUnit] = useState<string>(":");
+
+  const handleRatioUnitChange = (unit: string) => {
+    setRatioUnit(unit);
+    const list = (form.getFieldValue("runnerLayers") || []) as any[];
+    form.setFieldValue(
+      "runnerLayers",
+      list.map((item) => ({
+        ...item,
+        ratio: { ...(item.ratio || {}), unit },
+      }))
+    );
+  };
   return (
     <>
       <ProCard
@@ -178,19 +192,24 @@ export const Product = () => {
               unit="mm"
             />
           </Col>
-          <Col xs={12} md={6}>
-            <IntervalInputFormItem
-              name="production"
-              label="适用产量"
-              rules={[{ required: true, message: "请输入适用产量范围" }]}
-              placeholder={"产量"}
-              units={["kg/h", "l/h"]}
-            />
-          </Col>
-
-          <Form.Item noStyle dependencies={["extrudeType", "runnerNumber"]}>
+          <Form.Item noStyle dependencies={["runnerNumber"]}>
             {({ getFieldValue }) =>
-              getFieldValue("extrudeType") === "模内共挤" &&
+              getFieldValue("runnerNumber") > 1 ? null : (
+                <Col xs={12} md={6}>
+                  <IntervalInputFormItem
+                    name="production"
+                    label="适用产量"
+                    rules={[{ required: true, message: "请输入适用产量范围" }]}
+                    placeholder={"产量"}
+                    units={["kg/h", "l/h"]}
+                  />
+                </Col>
+              )
+            }
+          </Form.Item>
+
+          <Form.Item noStyle dependencies={["runnerNumber"]}>
+            {({ getFieldValue }) =>
               getFieldValue("runnerNumber") > 1 ? null : (
                 <Col xs={12} md={6}>
                   <IntervalInputFormItem
@@ -266,8 +285,11 @@ export const Product = () => {
                               materials={
                                 Array.isArray(material) ? material : [material]
                               }
+                              ratioUnit={ratioUnit}
+                              onRatioUnitChange={handleRatioUnitChange}
                             />
                           }
+                          creatorRecord={{ ratio: { unit: ratioUnit } }}
                         />
                       )}
                     </ProFormDependency>

--- a/src/components/quoteForm/formComponents/RunnerLayerItem.tsx
+++ b/src/components/quoteForm/formComponents/RunnerLayerItem.tsx
@@ -6,8 +6,14 @@ import MaterialSelect from "@/components/general/MaterialSelect";
 interface RunnerLayerItemProps {
   /** 可选材料列表 */
   materials?: string[];
+  ratioUnit?: string;
+  onRatioUnitChange?: (unit: string) => void;
 }
-const RunnerLayerItem: React.FC<RunnerLayerItemProps> = ({ materials }) => {
+const RunnerLayerItem: React.FC<RunnerLayerItemProps> = ({
+  materials,
+  ratioUnit = ":",
+  onRatioUnitChange,
+}) => {
   return (
     <Row gutter={16}>
       <Col xs={4} md={2}>
@@ -47,7 +53,14 @@ const RunnerLayerItem: React.FC<RunnerLayerItemProps> = ({ materials }) => {
             },
           ]}
         >
-          <IntervalInput unit="%" style={{ width: 120 }} />
+          <IntervalInput
+            unit={ratioUnit}
+            units={[":", "%"]}
+            style={{ width: 120 }}
+            onChange={(v) => {
+              if (v.unit !== ratioUnit) onRatioUnitChange?.(v.unit);
+            }}
+          />
         </ProForm.Item>
       </Col>
       <Col xs={8} md={6}>


### PR DESCRIPTION
## Summary
- hide production and temperature fields when runnerNumber > 1
- allow runner layer ratio units to be ':' or '%' and sync across list
- support syncing ratio units in manifold form as well

## Testing
- `npm install` *(fails: registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687a898a6f388327aa3b53697ffba5fb